### PR TITLE
Try ManualSplit

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ check the `Use Layout` checkbox, click `Browse` next to that,
 and navigate to the Layout file from before.
 Select it and click `Ok`.
 
-Finally, do not manually split, skip, or undo splits while running with this autosplitter.
+Finally, do not manually split or skip while running with this autosplitter,
+unless either it's explicitly marked as `ManualSplit` or it's the end-split.
+Don't manually split, skip, or undo splits in any other situation.
 The autosplitter will not know that you did that, and the autosplitter's state will be out of sync with LiveSplit's state.
 
 ## Instructions for livesplit-one-druid
@@ -131,7 +133,9 @@ cargo build --release
 sudo ./target/release/livesplit-one
 ```
 
-Finally, do not manually split, skip, or undo splits while running with this autosplitter.
+Finally, do not manually split or skip while running with this autosplitter,
+unless either it's explicitly marked as `ManualSplit` or it's the end-split.
+Don't manually split, skip, or undo splits in any other situation.
 The autosplitter will not know that you did that,
 and the autosplitter's state will be out of sync with `livesplit-one-druid`'s state.
 
@@ -171,7 +175,9 @@ cargo build --release
 sudo ./target/release/livesplit-one
 ```
 
-Finally, do not manually split, skip, or undo splits while running with this autosplitter.
+Finally, do not manually split or skip while running with this autosplitter,
+unless either it's explicitly marked as `ManualSplit` or it's the end-split.
+Don't manually split, skip, or undo splits in any other situation.
 The autosplitter will not know that you did that,
 and the autosplitter's state will be out of sync with `livesplit-one-desktop`'s state.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ fn splitter_action(a: SplitterAction, i: &mut usize, n: usize) {
             *i += 1;
         }
         SplitterAction::ManualSplit => {
-            if 0 < *i {
+            if 0 < *i && *i + 1 < n {
                 *i += 1;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,11 @@ async fn tick_action(
                 splitter_action(SplitterAction::Reset, i, n);
                 break;
             }
+            SplitterAction::ManualSplit => {
+                splitter_action(SplitterAction::ManualSplit, i, n);
+                next_tick().await;
+                break;
+            }
             SplitterAction::Pass => {
                 if auto_reset {
                     match splits::splits(&splits[0], &process, &game_manager_finder, trans_now, scene_store, player_data_store) {
@@ -200,6 +205,11 @@ fn splitter_action(a: SplitterAction, i: &mut usize, n: usize) {
         SplitterAction::Split => {
             asr::timer::split();
             *i += 1;
+        }
+        SplitterAction::ManualSplit => {
+            if 0 < *i {
+                *i += 1;
+            }
         }
     }
     if n <= *i {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -15,6 +15,7 @@ pub enum SplitterAction {
     Split,
     Skip,
     Reset,
+    ManualSplit,
 }
 
 impl SplitterAction {
@@ -53,6 +54,11 @@ fn should_split_skip(mb: Option<bool>) -> SplitterAction {
 #[derive(Clone, Debug, Default, Deserialize, Eq, Gui, Ord, PartialEq, PartialOrd, RadioButtonOptions, Serialize)]
 pub enum Split {
     // region: Start, End, and Menu
+    /// Manual Split (Misc)
+    /// 
+    /// Never splits. Use this when you need to manually split while using ordered splits
+    #[default]
+    ManualSplit,
     /// Start New Game (Start)
     /// 
     /// Splits when starting a new save file, including Normal, Steel Soul, and Godseeker mode
@@ -72,7 +78,6 @@ pub enum Split {
     /// Credits Roll (Event)
     /// 
     /// Splits on any credits rolling
-    #[default]
     EndingSplit,
     /// The Hollow Knight (Ending)
     /// 
@@ -3329,6 +3334,7 @@ pub fn transition_once_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &Game
 
 pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mut PlayerDataStore) -> SplitterAction {
     match s {
+        Split::ManualSplit => SplitterAction::ManualSplit,
         Split::RandoWake => should_split(g.disable_pause(p).is_some_and(|d| !d)
                                          && g.get_game_state(p).is_some_and(|s| s == GAME_STATE_PLAYING)
                                          && g.get_scene_name(p).is_some_and(|s| !is_menu(&s))),


### PR DESCRIPTION
Implementing the idea from https://github.com/AlexKnauth/wasm-hollowknight-autosplit-prototype/issues/12#issuecomment-1891000728: have the autosplitter automatically move on to the next split for its own internal state, but *without* sending a split action or any other action to the timer.

Testing:
 - [x] Implicit starting split that doesn't autostart so manual start is expected
 - [x] Implicit ending split that doesn't autosplit so manual split is expected
 - [x] Explicit `ManualSplit` as the starting split
 - [x] Explicit `ManualSplit` as the ending split
 - [x] Explicit `ManualSplit` as a middle split
