### PR TITLE
EnterTMG: check Grimmchild equipped

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -346,6 +346,7 @@ struct PlayerDataPointers {
     fragile_strength_unbreakable: UnityPointer<3>,
     // Grimmchild / Carefree Melody
     got_charm_40: UnityPointer<3>,
+    equipped_charm_40: UnityPointer<3>,
     grimm_child_level: UnityPointer<3>,
     flames_collected: UnityPointer<3>,
     got_brumms_flame: UnityPointer<3>,
@@ -692,6 +693,7 @@ impl PlayerDataPointers {
             fragile_strength_unbreakable: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "fragileStrength_unbreakable"]),
             // Grimmchild / Carefree Melody
             got_charm_40: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "gotCharm_40"]),
+            equipped_charm_40: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "equippedCharm_40"]),
             grimm_child_level: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "grimmChildLevel"]),
             flames_collected: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "flamesCollected"]),
             got_brumms_flame: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "gotBrummsFlame"]),
@@ -1579,6 +1581,10 @@ impl GameManagerFinder {
 
     pub fn got_charm_40(&self, process: &Process) -> Option<bool> {
         self.player_data_pointers.got_charm_40.deref(process, &self.module, &self.image).ok()
+    }
+
+    pub fn equipped_charm_40(&self, process: &Process) -> Option<bool> {
+        self.player_data_pointers.equipped_charm_40.deref(process, &self.module, &self.image).ok()
     }
 
     pub fn grimm_child_level(&self, process: &Process) -> Option<i32> {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3156,9 +3156,9 @@ pub fn transition_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &GameManag
         Split::SlyShopExit => should_split(p.old == "Room_shop" && p.current != p.old),
         Split::LumaflyLanternTransition => should_split(pds.has_lantern(prc, g) && !p.current.starts_with("Room_shop")),
         Split::SlyShopFinished => should_split(pds.sly_shop_finished(prc, g) && !p.current.starts_with("Room_shop")),
-        // TODO: should EnterTMG check that Grimmchild is actually equipped?
         Split::EnterTMG => should_split(p.current.starts_with("Grimm_Main_Tent")
                                         && p.current != p.old
+                                        && g.equipped_charm_40(prc).is_some_and(|e| e)
                                         && g.grimm_child_level(prc).is_some_and(|l| l == 2)
                                         && g.flames_collected(prc).is_some_and(|f| 3 <= f)),
         Split::EnterNKG => should_split(p.old.starts_with("Grimm_Main_Tent") && p.current.starts_with("Grimm_Nightmare")),


### PR DESCRIPTION
Testing:
 - [x] Don't split `EnterTMG` without level 2
 - [x] Don't split `EnterTMG` without 3 flames
 - [x] Don't split `EnterTMG` without Grimmchild equipped
 - [x] Split `EnterTMG` when entering the Grimm main tent with Grimmchild equipped 3 flames level 2
 - [x] While you're at it, also check `CarefreeMelody`