### PR TITLE
Start on detecting 64-bit vs 32-bit

### DIFF
--- a/src/auto_splitter_settings.rs
+++ b/src/auto_splitter_settings.rs
@@ -1,12 +1,12 @@
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 use asr::future::retry;
-use std::{path::Path, fs::File, io::{self, Read}};
+use std::path::Path;
 use xmltree::{Element, XMLNode};
 
 use ugly_widget::radio_button::options_str;
 
-use crate::{legacy_xml, splits::Split};
+use crate::{file, legacy_xml, splits::Split};
 
 pub async fn wait_asr_settings_init() -> asr::settings::Map {
     let settings1 = asr::settings::Map::load();
@@ -58,7 +58,7 @@ fn asr_settings_from_splits(splits: &[Split]) -> asr::settings::Map {
 }
 
 fn file_find_auto_splitter_settings<P: AsRef<Path>>(path: P) -> Option<Vec<XMLNode>> {
-    let bs = file_read_all_bytes(path).ok()?;
+    let bs = file::file_read_all_bytes(path).ok()?;
     let es = Element::parse_all(bs.as_slice()).ok()?;
     let auto_splitter_settings = es.iter().find_map(xml_find_auto_splitter_settings)?;
     Some(auto_splitter_settings)
@@ -150,9 +150,3 @@ fn maybe_asr_settings_list_merge(old: Option<asr::settings::List>, new: &asr::se
 
 // --------------------------------------------------------
 
-fn file_read_all_bytes<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
-    let mut f = File::open(path)?;
-    let mut buffer: Vec<u8> = Vec::new();
-    f.read_to_end(&mut buffer)?;
-    Ok(buffer)
-}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,11 @@
+
+use alloc::vec::Vec;
+
+use std::{path::Path, fs::File, io::{self, Read}};
+
+pub fn file_read_all_bytes<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
+    let mut f = File::open(path)?;
+    let mut buffer: Vec<u8> = Vec::new();
+    f.read_to_end(&mut buffer)?;
+    Ok(buffer)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 mod auto_splitter_settings;
+mod file;
 mod hollow_knight_memory;
 mod legacy_xml;
 mod settings_gui;


### PR DESCRIPTION
There's gotta be a better way to do this. The field is right there in the Rust `asr` crate, but it's private? Anyway this works for now even if it's wildly inefficient.