### PR TITLE
Add TimingMethod to legacy XML

### DIFF
--- a/splits-direct.lss
+++ b/splits-direct.lss
@@ -178,5 +178,6 @@
       <Split>MaskFragment3</Split>
       <Split>Mask1</Split>
     </Splits>
+    <TimingMethod>LoadRemovedTime</TimingMethod>
   </AutoSplitterSettings>
 </Run>

--- a/src/AutoSplitterSettings.txt
+++ b/src/AutoSplitterSettings.txt
@@ -16,3 +16,4 @@
       <Split>MaskFragment3</Split>
       <Split>Mask1</Split>
     </Splits>
+    <TimingMethod>LoadRemovedTime</TimingMethod>

--- a/src/auto_splitter_settings.rs
+++ b/src/auto_splitter_settings.rs
@@ -4,9 +4,7 @@ use asr::future::retry;
 use std::path::Path;
 use xmltree::{Element, XMLNode};
 
-use ugly_widget::radio_button::options_str;
-
-use crate::{file, legacy_xml, splits::Split};
+use crate::{file, legacy_xml};
 
 pub async fn wait_asr_settings_init() -> asr::settings::Map {
     let settings1 = asr::settings::Map::load();
@@ -42,19 +40,8 @@ fn asr_settings_from_xml_string(xml_string: &str) -> Option<asr::settings::Map> 
 }
 
 fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::settings::Map> {
-    let splits = legacy_xml::splits_from_xml_nodes(xml_nodes)?;
-    Some(asr_settings_from_splits(&splits))
-}
-
-fn asr_settings_from_splits(splits: &[Split]) -> asr::settings::Map {
-    // new empty map, which will only include the new splits
-    let settings_map = asr::settings::Map::new();
-    let l = asr::settings::List::new();
-    for split in splits.iter() {
-        l.push(options_str(split));
-    }
-    settings_map.insert("splits", l);
-    settings_map
+    // TODO: deal with either Legacy XML or ASR XML
+    legacy_xml::asr_settings_from_xml_nodes(xml_nodes)
 }
 
 fn file_find_auto_splitter_settings<P: AsRef<Path>>(path: P) -> Option<Vec<XMLNode>> {

--- a/src/legacy_xml.rs
+++ b/src/legacy_xml.rs
@@ -1,7 +1,24 @@
 
+use ugly_widget::radio_button::options_str;
 use xmltree::XMLNode;
 
 use crate::splits::Split;
+
+pub fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::settings::Map> {
+    let splits = splits_from_xml_nodes(xml_nodes)?;
+    Some(asr_settings_from_splits(&splits))
+}
+
+fn asr_settings_from_splits(splits: &[Split]) -> asr::settings::Map {
+    // new empty map, which will only include the new splits
+    let settings_map = asr::settings::Map::new();
+    let l = asr::settings::List::new();
+    for split in splits.iter() {
+        l.push(options_str(split));
+    }
+    settings_map.insert("splits", l);
+    settings_map
+}
 
 #[derive(Clone, Debug)]
 struct XMLSettings {

--- a/src/legacy_xml.rs
+++ b/src/legacy_xml.rs
@@ -5,7 +5,8 @@ use xmltree::XMLNode;
 use crate::splits::Split;
 
 pub fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::settings::Map> {
-    let splits = splits_from_xml_nodes(xml_nodes)?;
+    let xml_settings = XMLSettings::from_xml_nodes(xml_nodes, &[("Splits", "Split")]);
+    let splits = splits_from_settings(&xml_settings)?;
     // new empty map, which will only include the new splits
     let settings_map = asr::settings::Map::new();
     settings_map.insert("splits", asr_list_from_splits(&splits));
@@ -94,11 +95,6 @@ impl XMLSettings {
         }
         None
     }
-}
-
-pub fn splits_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<Vec<Split>> {
-    let xml_settings = XMLSettings::from_xml_nodes(xml_nodes, &[("Splits", "Split")]);
-    splits_from_settings(&xml_settings)
 }
 
 fn splits_from_settings(s: &XMLSettings) -> Option<Vec<Split>> {

--- a/src/legacy_xml.rs
+++ b/src/legacy_xml.rs
@@ -2,7 +2,7 @@
 use ugly_widget::radio_button::options_str;
 use xmltree::XMLNode;
 
-use crate::splits::Split;
+use crate::{settings_gui::TimingMethod, splits::Split};
 
 pub fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::settings::Map> {
     let xml_settings = XMLSettings::from_xml_nodes(xml_nodes, &[("Splits", "Split")]);
@@ -10,6 +10,10 @@ pub fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::setti
     // new empty map, which will only include the new splits
     let settings_map = asr::settings::Map::new();
     settings_map.insert("splits", asr_list_from_splits(&splits));
+    if let Some(timing_method) = xml_settings.dict_get("TimingMethod") {
+        let tm = timing_method_from_settings_str(timing_method).unwrap_or_default();
+        settings_map.insert("timing_method", options_str(&tm));
+    }
     Some(settings_map)
 }
 
@@ -131,5 +135,9 @@ fn split_from_settings_split(s: XMLSettings) -> Option<Split> {
 }
 
 fn split_from_settings_str(s: XMLSettings) -> Option<Split> {
+    serde_json::value::from_value(serde_json::Value::String(s.as_string()?)).ok()
+}
+
+fn timing_method_from_settings_str(s: XMLSettings) -> Option<TimingMethod> {
     serde_json::value::from_value(serde_json::Value::String(s.as_string()?)).ok()
 }

--- a/src/legacy_xml.rs
+++ b/src/legacy_xml.rs
@@ -6,18 +6,18 @@ use crate::splits::Split;
 
 pub fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::settings::Map> {
     let splits = splits_from_xml_nodes(xml_nodes)?;
-    Some(asr_settings_from_splits(&splits))
-}
-
-fn asr_settings_from_splits(splits: &[Split]) -> asr::settings::Map {
     // new empty map, which will only include the new splits
     let settings_map = asr::settings::Map::new();
+    settings_map.insert("splits", asr_list_from_splits(&splits));
+    Some(settings_map)
+}
+
+fn asr_list_from_splits(splits: &[Split]) -> asr::settings::List {
     let l = asr::settings::List::new();
     for split in splits.iter() {
         l.push(options_str(split));
     }
-    settings_map.insert("splits", l);
-    settings_map
+    l
 }
 
 #[derive(Clone, Debug)]

--- a/src/settings_gui.rs
+++ b/src/settings_gui.rs
@@ -1,9 +1,11 @@
 use asr::{settings::gui::{FileSelect, Gui, Title, Widget}, watcher::Pair};
 
+use serde::{Deserialize, Serialize};
 use ugly_widget::{
-    ugly_list::{UglyList, UglyListArgs},
-    store::{StoreWidget, StoreGui},
     args::SetHeadingLevel,
+    radio_button::RadioButtonOptions,
+    store::{StoreWidget, StoreGui},
+    ugly_list::{UglyList, UglyListArgs}
 };
 
 use crate::{
@@ -61,7 +63,7 @@ impl SettingsGui {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, Gui, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Gui, Ord, PartialEq, PartialOrd, RadioButtonOptions, Serialize)]
 pub enum TimingMethod {
     /// Load Removed Time
     #[default]


### PR DESCRIPTION
Even though it won't be there in split files made for the existing `LiveSplit.HollowKnight` autosplitters, extending that seems the easiest way to support this setting on the LiveSplit One prototypes.