### PR TITLE
Fix auto-start: load_remover reset

### DIFF
--- a/splits/current/layout-lswasr.lsl
+++ b/splits/current/layout-lswasr.lsl
@@ -187,7 +187,7 @@
         <ScriptPath>C:\Users\Owner\Documents\git\LiveSplit\hollowknight-autosplit-wasm\target\wasm32-wasi\debug\hollowknight_autosplit_wasm.wasm</ScriptPath>
         <CustomSettings>
           <Setting id="splits" type="list">
-            <Setting type="string" value="LegacyStart" />
+            <Setting type="string" value="StartNewGame" />
             <Setting type="string" value="KingsPass" />
             <Setting type="string" value="Grub1" />
             <Setting type="string" value="EnterBroodingMawlek" />
@@ -202,7 +202,7 @@
             <Setting type="string" value="MaskFragment3" />
             <Setting type="string" value="Mask1" />
           </Setting>
-          <Setting id="splits_0_item" type="string" value="LegacyStart" />
+          <Setting id="splits_0_item" type="string" value="StartNewGame" />
           <Setting id="splits_1_item" type="string" value="KingsPass" />
           <Setting id="splits_2_item" type="string" value="Grub1" />
           <Setting id="splits_3_item" type="string" value="EnterBroodingMawlek" />

--- a/splits/current/splits-direct.lss
+++ b/splits/current/splits-direct.lss
@@ -162,7 +162,7 @@
   <AutoSplitterSettings>
     <Ordered>True</Ordered>
     <AutosplitEndRuns>True</AutosplitEndRuns>
-    <AutosplitStartRuns></AutosplitStartRuns>
+    <AutosplitStartRuns>StartNewGame</AutosplitStartRuns>
     <Splits>
       <Split>KingsPass</Split>
       <Split>Grub1</Split>

--- a/src/AutoSplitterSettings.txt
+++ b/src/AutoSplitterSettings.txt
@@ -1,6 +1,6 @@
     <Ordered>True</Ordered>
     <AutosplitEndRuns>True</AutosplitEndRuns>
-    <AutosplitStartRuns></AutosplitStartRuns>
+    <AutosplitStartRuns>StartNewGame</AutosplitStartRuns>
     <Splits>
       <Split>KingsPass</Split>
       <Split>Grub1</Split>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@ async fn tick_action(
                 // no break, allow other actions after a skip
             }
             SplitterAction::Reset => {
-                *i = 0;
                 splitter_action(SplitterAction::Reset, i, n, load_remover);
                 break;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,12 @@ async fn tick_action(
     let trans_now = scene_store.transition_now(&process, &game_manager_finder);
     loop {
         match splits::splits(&splits[*i], &process, &game_manager_finder, trans_now, scene_store, player_data_store) {
+            SplitterAction::Split if *i == 0 => {
+                splitter_action(SplitterAction::Split, i, n);
+                load_remover.reset();
+                next_tick().await;
+                break;
+            }
             SplitterAction::Split => {
                 splitter_action(SplitterAction::Split, i, n);
                 next_tick().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,8 @@ async fn tick_action(
             }
             SplitterAction::Reset => {
                 splitter_action(SplitterAction::Reset, i, n, load_remover);
-                break;
+                next_tick().await;
+                // no break, allow other actions after a reset
             }
             SplitterAction::ManualSplit => {
                 splitter_action(SplitterAction::ManualSplit, i, n, load_remover);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ async fn tick_action(
         // detect manual starts
         TimerState::Running if *i == 0 && is_timer_state_between_runs(*last_timer_state) => {
             *i = 1;
+            load_remover.reset();
             asr::print_message("Detected a manual start.");
         }
         // detect manual end-splits

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -4092,7 +4092,7 @@ fn entering_kings_pass(p: &Pair<&str>, prc: &Process, g: &GameManagerFinder) -> 
 
 pub fn auto_reset_safe(s: &[Split]) -> bool {
     let s_first = s.first();
-    (s_first == Some(&Split::StartNewGame) || s_first == Some(&Split::LegacyStart))
+    (s_first == Some(&Split::StartNewGame))
     && !s[1..].contains(&Split::StartNewGame)
     && !s[1..].contains(&Split::LegacyStart)
     && !s[0..(s.len()-1)].contains(&Split::EndingSplit)


### PR DESCRIPTION
Testing:
- [x] Exact 0 when auto-starting from fresh
- [x] Exact 0 when auto-starting after a run has ended
- [x] Exact 0 when auto-starting after a manual reset
- [x] Exact 0 when auto-reset-starting from out of the middle of a run
- [x] Exact 0 on manual start