### PR TITLE
Initialize load-remover before timer running

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,17 @@ impl LoadRemover {
     fn reset(&mut self) {}
 
     fn load_removal(&mut self, process: &Process, game_manager_finder: &GameManagerFinder, _i: usize) -> Option<()> {
+        // Initialize pointers for load-remover before timer is running
+        let maybe_ui_state = game_manager_finder.get_ui_state(process);
+        let maybe_scene_name =  game_manager_finder.get_scene_name(process);
+        let maybe_next_scene = game_manager_finder.get_next_scene_name(process);
+        let maybe_teleporting = game_manager_finder.camera_teleporting(process);
+        let maybe_game_state = game_manager_finder.get_game_state(process);
+        let maybe_hazard_respawning = game_manager_finder.hazard_respawning(process);
+        let maybe_accepting_input = game_manager_finder.accepting_input(process);
+        let maybe_hero_transition_state = game_manager_finder.hero_transition_state(process);
+        let maybe_tile_map_dirty = game_manager_finder.tile_map_dirty(process);
+        let maybe_uses_scene_transition_routine = game_manager_finder.uses_scene_transition_routine(process);
 
         // only remove loads if timer is running
         if asr::timer::state() != TimerState::Running {
@@ -277,12 +288,9 @@ impl LoadRemover {
             return Some(());
         }
 
-        let maybe_ui_state = game_manager_finder.get_ui_state(process);
         let ui_state = maybe_ui_state.unwrap_or_default();
 
-        let maybe_scene_name =  game_manager_finder.get_scene_name(process);
         let scene_name = maybe_scene_name.clone().unwrap_or_default();
-        let maybe_next_scene = game_manager_finder.get_next_scene_name(process);
         fn is_none_or_empty(ms: Option<&str>) -> bool {
             match ms {  None | Some("") => true, Some(_) => false }
         }
@@ -290,10 +298,8 @@ impl LoadRemover {
             || (scene_name != "Menu_Title" && maybe_next_scene.as_deref() == Some("Menu_Title")
                 || (scene_name == "Quit_To_Menu"));
 
-        let maybe_teleporting = game_manager_finder.camera_teleporting(process);
         let teleporting = maybe_teleporting.unwrap_or_default();
 
-        let maybe_game_state = game_manager_finder.get_game_state(process);
         let game_state = maybe_game_state.unwrap_or_default();
         if game_state == GAME_STATE_PLAYING && self.last_game_state == GAME_STATE_MAIN_MENU {
             self.look_for_teleporting = true;
@@ -303,15 +309,11 @@ impl LoadRemover {
         }
 
         // TODO: look into Current Patch quitout issues. // might have been fixed? cerpin you broke them in a way that made them work, right?
-        let maybe_hazard_respawning = game_manager_finder.hazard_respawning(process);
         let hazard_respawning = maybe_hazard_respawning.unwrap_or_default();
-        let maybe_accepting_input = game_manager_finder.accepting_input(process);
         let accepting_input = maybe_accepting_input.unwrap_or_default();
-        let maybe_hero_transition_state = game_manager_finder.hero_transition_state(process);
         let hero_transition_state = maybe_hero_transition_state.unwrap_or_default();
-        let maybe_tile_map_dirty = game_manager_finder.tile_map_dirty(process);
         let tile_map_dirty = maybe_tile_map_dirty.unwrap_or_default();
-        let uses_scene_transition_routine = game_manager_finder.uses_scene_transition_routine(process).unwrap_or_default();
+        let uses_scene_transition_routine = maybe_uses_scene_transition_routine.unwrap_or_default();
         let is_game_time_paused =
             (game_state == GAME_STATE_PLAYING && teleporting && !hazard_respawning)
             || (self.look_for_teleporting)


### PR DESCRIPTION
Fixes #54.

Testing:
- [x] The straight-line-test stag splits.