### PR TITLE
Split DgateKingdomsEdgeAcid

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -396,6 +396,9 @@ struct PlayerDataPointers {
     kills_grub_mimic: UnityPointer<3>,
     dream_orbs: UnityPointer<3>,
     scenes_encountered_dream_plant_c: UnityPointer<3>,
+    dream_gate_scene: UnityPointer<3>,
+    dream_gate_x: UnityPointer<3>,
+    dream_gate_y: UnityPointer<3>,
     map_dirtmouth: UnityPointer<3>,
     map_crossroads: UnityPointer<3>,
     map_greenpath: UnityPointer<3>,
@@ -756,6 +759,9 @@ impl PlayerDataPointers {
             kills_grub_mimic: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killsGrubMimic"]),
             dream_orbs: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dreamOrbs"]),
             scenes_encountered_dream_plant_c: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "scenesEncounteredDreamPlantC"]),
+            dream_gate_scene: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dreamGateScene"]),
+            dream_gate_x: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dreamGateX"]),
+            dream_gate_y: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dreamGateY"]),
             map_dirtmouth: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapDirtmouth"]),
             map_crossroads: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapCrossroads"]),
             map_greenpath: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapGreenpath"]),
@@ -1748,6 +1754,21 @@ impl GameManagerFinder {
             _ => { return None; }
         };
         read_string_list_object::<SCENE_PATH_SIZE>(process, &self.string_list_offests, l)
+    }
+
+    pub fn dream_gate_scene(&self, process: &Process) -> Option<String> {
+        let s: Address = match self.string_list_offests.pointer_size {
+            PointerSize::Bit64 => self.player_data_pointers.dream_gate_scene.deref::<Address64>(process, &self.module, &self.image).ok()?.into(),
+            PointerSize::Bit32 => self.player_data_pointers.dream_gate_scene.deref::<Address32>(process, &self.module, &self.image).ok()?.into(),
+            _ => { return None; }
+        };
+        read_string_object::<SCENE_PATH_SIZE>(process, &self.string_list_offests, s)
+    }
+    pub fn dream_gate_x(&self, process: &Process) -> Option<f32> {
+        self.player_data_pointers.dream_gate_x.deref(process, &self.module, &self.image).ok()
+    }
+    pub fn dream_gate_y(&self, process: &Process) -> Option<f32> {
+        self.player_data_pointers.dream_gate_y.deref(process, &self.module, &self.image).ok()
     }
 
     pub fn map_dirtmouth(&self, process: &Process) -> Option<bool> {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2417,6 +2417,10 @@ pub enum Split {
     /// 
     /// Splits when absorbing essence from Markoth
     MarkothEssence,
+    /// Kingdom's Edge Acid (Dreamgate)
+    /// 
+    /// Splits when placing Dreamgate by KE Acid (hopefully)
+    DgateKingdomsEdgeAcid,
     // endregion: Kingdom's Edge
     // region: Colosseum
     /// Little Fool (NPC)
@@ -4038,6 +4042,9 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::Hornet2 => should_split(g.hornet_outskirts_defeated(p).is_some_and(|k| k)),
         Split::Markoth => should_split(g.killed_ghost_markoth(p).is_some_and(|k| k)),
         Split::MarkothEssence => should_split(g.markoth_defeated(p).is_some_and(|d| d == 2)),
+        Split::DgateKingdomsEdgeAcid => should_split(g.dream_gate_scene(p).is_some_and(|s| s.starts_with("Deepnest_East_04"))
+                                                     && g.dream_gate_x(p).is_some_and(|x| 27.0f32 < x && x < 29f32)
+                                                     && g.dream_gate_y(p).is_some_and(|y| 7.0f32 < y && y < 9f32)),
         // endregion: Kingdom's Edge
         // region: Colosseum
         Split::LittleFool => should_split(g.little_fool_met(p).is_some_and(|m| m)),


### PR DESCRIPTION
- [x] Test while checking scene coordinates
- [x] See if the `match self.string_list_offests.pointer_size` pattern can be simplified or factored out