### PR TITLE
Split OnObtainGhostRevek

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3391,6 +3391,9 @@ impl SceneDataStore {
                 self.map_bool_items.insert(key, activated);
             }
         }
+        if killed == 0 {
+            revek_alone = false;
+        }
         if !self.map_bool_derived.get("revek_alone").is_some_and(|&prev_alone| prev_alone == revek_alone) {
             changed = true;
             asr::print_message(&format!("SceneData revek_alone: {}", revek_alone));

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -1028,6 +1028,7 @@ pub struct GameManagerFinder {
     pointers: Box<GameManagerPointers>,
     player_data_pointers: Box<PlayerDataPointers>,
     completion_pointers: Box<CompletionPointers>,
+    scene_data_pointers: Box<SceneDataPointers>,
     ui_state_offset: OnceCell<u32>,
     modded: OnceCell<bool>,
 }
@@ -1041,6 +1042,7 @@ impl GameManagerFinder {
             pointers: Box::new(GameManagerPointers::new()),
             player_data_pointers: Box::new(PlayerDataPointers::new()),
             completion_pointers: Box::new(CompletionPointers::new()),
+            scene_data_pointers: Box::new(SceneDataPointers::new()),
             ui_state_offset: OnceCell::new(),
             modded: OnceCell::new(),
         }
@@ -3313,6 +3315,29 @@ impl PlayerDataStore {
     pub fn gold_end(&mut self, prc: &Process, gmf: &GameManagerFinder) -> Option<bool> {
         // God Tamer: {0} +1 {1}
         self.kills_decreased_by(prc, gmf, "kills_lobster_lancer_on_entry", &gmf.player_data_pointers.kills_lobster_lancer, 1)
+    }
+}
+
+// --------------------------------------------------------
+
+pub struct SceneDataStore {
+    map_bool_items: BTreeMap<(String, String), bool>,
+}
+
+impl SceneDataStore {
+    pub fn new() -> SceneDataStore {
+        SceneDataStore { 
+            map_bool_items: BTreeMap::new(),
+        }
+    }
+    pub fn reset(&mut self) {
+        self.map_bool_items.clear();
+    }
+    
+    pub fn glade_ghosts_killed(&mut self, prc: &Process, gmf: &mut GameManagerFinder) -> Option<i32> {
+        let pbis = gmf.deref_pointer(prc, &gmf.scene_data_pointers.persistent_bool_items).ok()?;
+        let offsets = gmf.scene_data_pointers.offsets(prc, &gmf.module, &gmf.image)?;
+        None
     }
 }
 

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3339,9 +3339,10 @@ impl SceneDataStore {
         self.map_bool_items.clear();
     }
     
-    pub fn glade_ghosts_killed(&mut self, prc: &Process, gmf: &mut GameManagerFinder) -> Option<(bool, i32)> {
+    pub fn glade_ghosts_killed(&mut self, prc: &Process, gmf: &mut GameManagerFinder) -> Option<(bool, bool, i32)> {
         let pbis = gmf.deref_pointer(prc, &gmf.scene_data_pointers.persistent_bool_items).ok()?;
         let offsets = gmf.scene_data_pointers.offsets(prc, &gmf.module, &gmf.image)?;
+        let mut changed = false;
         let mut revek_alone = true;
         let mut killed = 0;
         for pbi in list_object_iter(prc, &gmf.string_list_offests, pbis)? {
@@ -3366,19 +3367,22 @@ impl SceneDataStore {
             }
             let key = (scene_str, id_str);
             if !self.map_bool_items.get(&key).is_some_and(|&prev_activated| prev_activated == activated) {
+                changed = true;
                 asr::print_message(&format!("SceneData {:?}: {}", key, activated));
                 self.map_bool_items.insert(key, activated);
             }
         }
         if !self.map_bool_derived.get("revek_alone").is_some_and(|&prev_alone| prev_alone == revek_alone) {
+            changed = true;
             asr::print_message(&format!("SceneData revek_alone: {}", revek_alone));
             self.map_bool_derived.insert("revek_alone", revek_alone);
         }
         if !self.map_i32_derived.get("glade_ghosts_killed").is_some_and(|&prev_killed| prev_killed == killed) {
+            changed = true;
             asr::print_message(&format!("SceneData glade_ghosts_killed: {}", killed));
             self.map_i32_derived.insert("glade_ghosts_killed", killed);
         }
-        Some((revek_alone, killed))
+        Some((changed, revek_alone, killed))
     }
 }
 

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3342,6 +3342,9 @@ impl SceneDataStore {
         let offsets = gmf.scene_data_pointers.offsets(prc, &gmf.module, &gmf.image)?;
         let mut killed = 0;
         for pbi in list_object_iter(prc, &gmf.string_list_offests, pbis)? {
+            if pbi.is_null() {
+                continue;
+            }
             let scene_addr = prc.read_pointer(pbi + offsets.persistentbooldata_scenename, gmf.string_list_offests.pointer_size).ok()?;
             let scene_str = read_string_object::<SCENE_PATH_SIZE>(prc, &gmf.string_list_offests, scene_addr)?;
             if !scene_str.starts_with("RestingGrounds_08") {

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -2825,6 +2825,25 @@ impl PlayerDataStore {
         self.incremented_i32(process, game_manager_finder, "dream_orbs", &game_manager_finder.player_data_pointers.dream_orbs)
     }
 
+    pub fn glade_essence_since_changed(&mut self, process: &Process, game_manager_finder: &GameManagerFinder, changed: bool) -> i32 {
+        let glade_essence_since_changed = if changed {
+            self.map_i32.insert("glade_essence_since_changed", 0);
+            0
+        } else if let Some(&glade_essence_since_changed) = self.map_i32.get("glade_essence_since_changed") {
+            glade_essence_since_changed
+        } else {
+            0
+        };
+        let o = self.incremented_dream_orbs(process, game_manager_finder);
+        if o && game_manager_finder.get_scene_name(process).is_some_and(|s| s.starts_with("RestingGrounds_08")) {
+            let next_glade_essence = glade_essence_since_changed + 1;
+            self.map_i32.insert("glade_essence_since_changed", next_glade_essence);
+            next_glade_essence
+        } else {
+            glade_essence_since_changed
+        }
+    }
+
     pub fn incremented_grey_prince_defeats(&mut self, process: &Process, game_manager_finder: &GameManagerFinder) -> bool {
         self.incremented_i32(process, game_manager_finder, "grey_prince_defeats", &game_manager_finder.player_data_pointers.grey_prince_defeats)
     }

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3352,7 +3352,7 @@ impl SceneDataStore {
             }
             let id_addr = prc.read_pointer(pbi + offsets.persistentbooldata_id, gmf.string_list_offests.pointer_size).ok()?;
             let id_str = read_string_object::<SCENE_PATH_SIZE>(prc, &gmf.string_list_offests, id_addr)?;
-            if !id_str.starts_with("Ghost ") {
+            if !(id_str.starts_with("Ghost ") || id_str.contains("karina")) {
                 continue;
             }
             let key = (scene_str, id_str);

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3323,12 +3323,14 @@ impl PlayerDataStore {
 
 pub struct SceneDataStore {
     map_bool_items: BTreeMap<(String, String), bool>,
+    map_i32_derived: BTreeMap<&'static str, i32>,
 }
 
 impl SceneDataStore {
     pub fn new() -> SceneDataStore {
         SceneDataStore { 
             map_bool_items: BTreeMap::new(),
+            map_i32_derived: BTreeMap::new(),
         }
     }
     pub fn reset(&mut self) {
@@ -3359,6 +3361,10 @@ impl SceneDataStore {
             if activated {
                 killed += 1;
             }
+        }
+        if !self.map_i32_derived.get("glade_ghosts_killed").is_some_and(|&prev_killed| prev_killed == killed) {
+            asr::print_message(&format!("SceneData glade_ghosts_killed: {}", killed));
+            self.map_i32_derived.insert("glade_ghosts_killed", killed);
         }
         Some(killed)
     }

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3387,6 +3387,7 @@ impl SceneDataStore {
             let key = (scene_str, id_str);
             if !self.map_bool_items.get(&key).is_some_and(|&prev_activated| prev_activated == activated) {
                 changed = true;
+                #[cfg(debug_assertions)]
                 asr::print_message(&format!("SceneData {:?}: {}", key, activated));
                 self.map_bool_items.insert(key, activated);
             }
@@ -3396,11 +3397,13 @@ impl SceneDataStore {
         }
         if !self.map_bool_derived.get("revek_alone").is_some_and(|&prev_alone| prev_alone == revek_alone) {
             changed = true;
+            #[cfg(debug_assertions)]
             asr::print_message(&format!("SceneData revek_alone: {}", revek_alone));
             self.map_bool_derived.insert("revek_alone", revek_alone);
         }
         if !self.map_i32_derived.get("glade_ghosts_killed").is_some_and(|&prev_killed| prev_killed == killed) {
             changed = true;
+            #[cfg(debug_assertions)]
             asr::print_message(&format!("SceneData glade_ghosts_killed: {}", killed));
             self.map_i32_derived.insert("glade_ghosts_killed", killed);
         }

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -1005,7 +1005,7 @@ impl SceneDataPointers {
         }
     }
 
-    fn offsets(&mut self, process: &Process, module: &Module, image: &Image) -> Option<&SceneDataOffsets> {
+    fn offsets(&self, process: &Process, module: &Module, image: &Image) -> Option<&SceneDataOffsets> {
         if let Some(o) = self.offsets.get() {
             return Some(o);
         }
@@ -3358,7 +3358,7 @@ impl SceneDataStore {
         self.map_bool_items.clear();
     }
     
-    pub fn glade_ghosts_killed(&mut self, prc: &Process, gmf: &mut GameManagerFinder) -> Option<(bool, bool, i32)> {
+    pub fn glade_ghosts_killed(&mut self, prc: &Process, gmf: &GameManagerFinder) -> Option<(bool, bool, i32)> {
         let pbis = gmf.deref_pointer(prc, &gmf.scene_data_pointers.persistent_bool_items).ok()?;
         let offsets = gmf.scene_data_pointers.offsets(prc, &gmf.module, &gmf.image)?;
         let mut changed = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ fn splitter_action(a: SplitterAction, i: &mut usize, n: usize, load_remover: &mu
             *i += 1;
         }
         SplitterAction::Split if *i == 0 => {
+            asr::timer::reset();
             asr::timer::start();
             load_remover.reset();
             *i += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ async fn main() {
                 let mut load_remover = Box::new(TimingMethodLoadRemover::new(timing_method));
 
                 next_tick().await;
-                let mut game_manager_finder = Box::new(GameManagerFinder::wait_attach(&process).await);
+                let game_manager_finder = Box::new(GameManagerFinder::wait_attach(&process).await);
                 let mut player_data_store = Box::new(PlayerDataStore::new());
                 let mut scene_data_store = Box::new(SceneDataStore::new());
 
@@ -71,7 +71,7 @@ async fn main() {
                 let mut last_timer_state = TimerState::Unknown;
                 let mut i = 0;
                 loop {
-                    tick_action(&process, &splits, &mut last_timer_state, &mut i, auto_reset, &mut game_manager_finder, &mut scene_store, &mut player_data_store, &mut scene_data_store, &mut load_remover).await;
+                    tick_action(&process, &splits, &mut last_timer_state, &mut i, auto_reset, &game_manager_finder, &mut scene_store, &mut player_data_store, &mut scene_data_store, &mut load_remover).await;
 
                     load_remover.load_removal(&process, &game_manager_finder, i);
 
@@ -115,7 +115,7 @@ async fn tick_action(
     last_timer_state: &mut TimerState,
     i: &mut usize,
     auto_reset: &'static [TimerState],
-    game_manager_finder: &mut GameManagerFinder,
+    game_manager_finder: &GameManagerFinder,
     scene_store: &mut SceneStore,
     player_data_store: &mut PlayerDataStore,
     scene_data_store: &mut SceneDataStore,

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3882,10 +3882,10 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds:
             should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "Hive_05"))
         }
         Split::OnObtainGhostRevek => {
-            let d = sds.glade_ghosts_killed(p, g).is_some_and(|k| 17 <= k);
+            let k = sds.glade_ghosts_killed(p, g).unwrap_or_default();
             let o = pds.incremented_dream_orbs(p, g);
             // make sure both SceneDataStore and PlayerDataStore methods are evaluated before the `&&` so it doesn't short-circuit
-            should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08"))
+            should_split(19 <= k || (18 <= k && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08")))
         }
         // endregion: Essence, Trees, and Ghosts
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1,6 +1,7 @@
 
 use asr::Process;
 use asr::settings::Gui;
+use asr::timer::TimerState;
 use asr::watcher::Pair;
 use serde::{Deserialize, Serialize};
 use ugly_widget::radio_button::{RadioButtonOptions, options_str};
@@ -4226,16 +4227,23 @@ fn entering_kings_pass(p: &Pair<&str>, prc: &Process, g: &GameManagerFinder) -> 
     })
 }
 
-pub fn auto_reset_safe(s: &[Split]) -> bool {
+pub fn auto_reset_safe(s: &[Split]) -> &'static [TimerState] {
     let s_first = s.first();
-    (s_first == Some(&Split::StartNewGame))
-    && !s[1..].contains(&Split::StartNewGame)
-    && !s[1..].contains(&Split::LegacyStart)
-    && !s[0..(s.len()-1)].contains(&Split::EndingSplit)
-    && !s[0..(s.len()-1)].contains(&Split::EndingA)
-    && !s[0..(s.len()-1)].contains(&Split::EndingB)
-    && !s[0..(s.len()-1)].contains(&Split::EndingC)
-    && !s[0..(s.len()-1)].contains(&Split::EndingD)
-    && !s[0..(s.len()-1)].contains(&Split::EndingE)
-    && !s[0..(s.len()-1)].contains(&Split::RadianceP)
+    if (s_first == Some(&Split::StartNewGame))
+       && !s[1..].contains(&Split::StartNewGame)
+       && !s[1..].contains(&Split::LegacyStart)
+       && !s[0..(s.len()-1)].contains(&Split::EndingSplit)
+       && !s[0..(s.len()-1)].contains(&Split::EndingA)
+       && !s[0..(s.len()-1)].contains(&Split::EndingB)
+       && !s[0..(s.len()-1)].contains(&Split::EndingC)
+       && !s[0..(s.len()-1)].contains(&Split::EndingD)
+       && !s[0..(s.len()-1)].contains(&Split::EndingE)
+       && !s[0..(s.len()-1)].contains(&Split::RadianceP)
+    {
+        &[TimerState::Ended, TimerState::Running]
+    } else if s_first == Some(&Split::StartNewGame) || s_first == Some(&Split::LegacyStart) {
+        &[TimerState::Ended]
+    } else {
+        &[]
+    }
 }

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3466,7 +3466,7 @@ pub fn transition_once_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &Game
     }
 }
 
-pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds: &mut PlayerDataStore, sds: &mut SceneDataStore) -> SplitterAction {
+pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mut PlayerDataStore, sds: &mut SceneDataStore) -> SplitterAction {
     match s {
         Split::ManualSplit => SplitterAction::ManualSplit,
         Split::RandoWake => should_split(g.disable_pause(p).is_some_and(|d| !d)
@@ -4197,7 +4197,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds:
     }
 }
 
-pub fn splits(s: &Split, prc: &Process, g: &mut GameManagerFinder, trans_now: bool, ss: &mut SceneStore, pds: &mut PlayerDataStore, sds: &mut SceneDataStore) -> SplitterAction {
+pub fn splits(s: &Split, prc: &Process, g: &GameManagerFinder, trans_now: bool, ss: &mut SceneStore, pds: &mut PlayerDataStore, sds: &mut SceneDataStore) -> SplitterAction {
     #[cfg(debug_assertions)]
     pds.get_game_state(prc, g);
     let a1 = continuous_splits(s, prc, g, pds, sds).or_else(|| {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3882,7 +3882,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds:
             should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "Hive_05"))
         }
         Split::OnObtainGhostRevek => {
-            let (a, k) = sds.glade_ghosts_killed(p, g).unwrap_or_default();
+            let (_, a, k) = sds.glade_ghosts_killed(p, g).unwrap_or_default();
             let o = pds.incremented_dream_orbs(p, g);
             // make sure both SceneDataStore and PlayerDataStore methods are evaluated before the `&&` so it doesn't short-circuit
             should_split(a && (19 <= k || (18 <= k && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08"))))

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3882,10 +3882,10 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds:
             should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "Hive_05"))
         }
         Split::OnObtainGhostRevek => {
-            let k = sds.glade_ghosts_killed(p, g).unwrap_or_default();
+            let (a, k) = sds.glade_ghosts_killed(p, g).unwrap_or_default();
             let o = pds.incremented_dream_orbs(p, g);
             // make sure both SceneDataStore and PlayerDataStore methods are evaluated before the `&&` so it doesn't short-circuit
-            should_split(19 <= k || (18 <= k && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08")))
+            should_split(a && (19 <= k || (18 <= k && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08"))))
         }
         // endregion: Essence, Trees, and Ghosts
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3882,10 +3882,10 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds:
             should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "Hive_05"))
         }
         Split::OnObtainGhostRevek => {
-            let (_, a, k) = sds.glade_ghosts_killed(p, g).unwrap_or_default();
-            let o = pds.incremented_dream_orbs(p, g);
+            let (c, a, k) = sds.glade_ghosts_killed(p, g).unwrap_or_default();
+            let o = pds.glade_essence_since_changed(p, g, c);
             // make sure both SceneDataStore and PlayerDataStore methods are evaluated before the `&&` so it doesn't short-circuit
-            should_split(a && (19 <= k || (18 <= k && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08"))))
+            should_split(a && (19 <= k + o))
         }
         // endregion: Essence, Trees, and Ghosts
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3882,7 +3882,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &mut GameManagerFinder, pds:
             should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "Hive_05"))
         }
         Split::OnObtainGhostRevek => {
-            let d = sds.glade_ghosts_killed(p, g).is_some_and(|k| 18 <= k);
+            let d = sds.glade_ghosts_killed(p, g).is_some_and(|k| 17 <= k);
             let o = pds.incremented_dream_orbs(p, g);
             // make sure both SceneDataStore and PlayerDataStore methods are evaluated before the `&&` so it doesn't short-circuit
             should_split(d && o && g.get_scene_name(p).is_some_and(|s| s == "RestingGrounds_08"))


### PR DESCRIPTION
Closes #57.

- [x] Check that the SceneData access works
- [x] Don't split `OnObtainGhostRevek` when mixing ghost essence with tree essence
- [x] Split `OnObtainGhostRevek` when getting all glade ghosts including Revek and Karina
- [x] SceneData debug information only in debug mode, not release
- [x] See if some of the mutable borrows can be removed