### PR TITLE
Split WhiteDefenderStatueUnlocked

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -186,6 +186,14 @@ pub const UI_STATE_PAUSED: i32 = 7;
 
 pub const HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL: i32 = 2;
 
+#[derive(bytemuck::CheckedBitPattern, Clone, Copy)]
+#[repr(C)]
+pub struct Vector3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
 struct GameManagerPointers {
     version_number: UnityPointer<4>,
     scene_name: UnityPointer<2>,
@@ -194,6 +202,7 @@ struct GameManagerPointers {
     ui_state_vanilla: UnityPointer<3>,
     ui_state_modded: UnityPointer<3>,
     camera_teleporting: UnityPointer<3>,
+    camera_target_destination: UnityPointer<4>,
     accepting_input: UnityPointer<3>,
     tile_map_dirty: UnityPointer<2>,
     hero_dead: UnityPointer<4>,
@@ -215,6 +224,7 @@ impl GameManagerPointers {
             ui_state_vanilla: UnityPointer::new("GameManager", 0, &["_instance", "<ui>k__BackingField", "uiState"]),
             ui_state_modded: UnityPointer::new("GameManager", 0, &["_instance", "_uiInstance", "uiState"]),
             camera_teleporting: UnityPointer::new("GameManager", 0, &["_instance", "<cameraCtrl>k__BackingField", "teleporting"]),
+            camera_target_destination: UnityPointer::new("GameManager", 0, &["_instance", "<cameraCtrl>k__BackingField", "camTarget", "destination"]),
             accepting_input: UnityPointer::new("GameManager", 0, &["_instance", "<inputHandler>k__BackingField", "acceptingInput"]),
             tile_map_dirty: UnityPointer::new("GameManager", 0, &["_instance", "tilemapDirty"]),
             hero_dead: UnityPointer::new("GameManager", 0, &["_instance", "<hero_ctrl>k__BackingField", "cState", "dead"]),
@@ -1143,6 +1153,10 @@ impl GameManagerFinder {
 
     pub fn camera_teleporting(&self, process: &Process) -> Option<bool> {
         self.pointers.camera_teleporting.deref(process, &self.module, &self.image).ok()
+    }
+
+    pub fn camera_target_destination(&self, process: &Process) -> Option<Vector3> {
+        self.pointers.camera_target_destination.deref(process, &self.module, &self.image).ok()
     }
 
     pub fn hazard_respawning(&self, process: &Process) -> Option<bool> {

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -504,6 +504,7 @@ struct PlayerDataPointers {
     killed_white_defender: UnityPointer<3>,
     white_defender_orbs_collected: UnityPointer<3>,
     white_defender_defeats: UnityPointer<3>,
+    dung_defender_awake_convo: UnityPointer<3>,
     met_emilitia: UnityPointer<3>,
     given_emilitia_flower: UnityPointer<3>,
     killed_fluke_mother: UnityPointer<3>,
@@ -859,6 +860,7 @@ impl PlayerDataPointers {
             killed_white_defender: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killedWhiteDefender"]),
             white_defender_orbs_collected: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "whiteDefenderOrbsCollected"]),
             white_defender_defeats: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "whiteDefenderDefeats"]),
+            dung_defender_awake_convo: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dungDefenderAwakeConvo"]),
             met_emilitia: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "metEmilitia"]),
             given_emilitia_flower: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "givenEmilitiaFlower"]),
             killed_fluke_mother: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killedFlukeMother"]),
@@ -2854,6 +2856,24 @@ impl PlayerDataStore {
 
     pub fn incremented_white_defender_defeats(&mut self, process: &Process, game_manager_finder: &GameManagerFinder) -> bool {
         self.incremented_i32(process, game_manager_finder, "white_defender_defeats", &game_manager_finder.player_data_pointers.white_defender_defeats)
+    }
+
+    pub fn dung_defender_awake_convo_on_entry(&mut self, prc: &Process, gmf: &GameManagerFinder) -> bool {
+        if gmf.is_game_state_non_continuous(prc) {
+            self.map_bool.remove("dung_defender_awake_convo_on_entry");
+            return false;
+        }
+        match self.map_bool.get("dung_defender_awake_convo_on_entry") {
+            None => {
+                if let Ok(convo_now) = gmf.player_data_pointers.dung_defender_awake_convo.deref(prc, &gmf.module, &gmf.image) {
+                    self.map_bool.insert("dung_defender_awake_convo_on_entry", convo_now);
+                    convo_now
+                } else {
+                    false
+                }
+            }
+            Some(convo_on_entry) => *convo_on_entry
+        }
     }
 
     pub fn zote_rescued_buzzer(&mut self, p: &Process, g: &GameManagerFinder) -> bool {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -4071,7 +4071,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::OnDefeatWhiteDefender => should_split(pds.incremented_white_defender_defeats(p, g)),
         Split::WhiteDefenderStatueUnlocked => should_split(pds.dung_defender_awake_convo_on_entry(p, g)
                                                            && g.get_scene_name(p).is_some_and(|s| s.starts_with("Waterways_15"))
-                                                           && g.camera_target_destination(p).is_some_and(|v| v.x < 30.0)),
+                                                           && g.camera_target_destination(p).is_some_and(|v| v.x < 29.5)),
         Split::MetEmilitia => should_split(g.met_emilitia(p).is_some_and(|m| m)),
         Split::GivenEmilitiaFlower => should_split(g.given_emilitia_flower(p).is_some_and(|g| g)),
         Split::Flukemarm => should_split(g.killed_fluke_mother(p).is_some_and(|k| k)),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2220,6 +2220,10 @@ pub enum Split {
     /// 
     /// Splits each time defeating White Defender in Dung Defender's dream
     OnDefeatWhiteDefender,
+    /// Stinky (Event)
+    /// 
+    /// Splits when seeing the Dung Defender's statue of the Knight
+    WhiteDefenderStatueUnlocked,
     /// Met Emilitia (Event)
     /// 
     /// Splits when talking to Emilitia for the first time
@@ -4065,6 +4069,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::WhiteDefender => should_split(g.killed_white_defender(p).is_some_and(|k| k)),
         Split::WhiteDefenderEssence => should_split(g.white_defender_orbs_collected(p).is_some_and(|o| o)),
         Split::OnDefeatWhiteDefender => should_split(pds.incremented_white_defender_defeats(p, g)),
+        Split::WhiteDefenderStatueUnlocked => todo!("WhiteDefenderStatueUnlocked"),
         Split::MetEmilitia => should_split(g.met_emilitia(p).is_some_and(|m| m)),
         Split::GivenEmilitiaFlower => should_split(g.given_emilitia_flower(p).is_some_and(|g| g)),
         Split::Flukemarm => should_split(g.killed_fluke_mother(p).is_some_and(|k| k)),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -4071,7 +4071,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::OnDefeatWhiteDefender => should_split(pds.incremented_white_defender_defeats(p, g)),
         Split::WhiteDefenderStatueUnlocked => should_split(pds.dung_defender_awake_convo_on_entry(p, g)
                                                            && g.get_scene_name(p).is_some_and(|s| s.starts_with("Waterways_15"))
-                                                           && g.camera_target_destination(p).is_some_and(|v| v.x < 29.5)),
+                                                           && g.camera_target_destination(p).is_some_and(|v| v.x < 30.0)),
         Split::MetEmilitia => should_split(g.met_emilitia(p).is_some_and(|m| m)),
         Split::GivenEmilitiaFlower => should_split(g.given_emilitia_flower(p).is_some_and(|g| g)),
         Split::Flukemarm => should_split(g.killed_fluke_mother(p).is_some_and(|k| k)),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -4069,9 +4069,9 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::WhiteDefender => should_split(g.killed_white_defender(p).is_some_and(|k| k)),
         Split::WhiteDefenderEssence => should_split(g.white_defender_orbs_collected(p).is_some_and(|o| o)),
         Split::OnDefeatWhiteDefender => should_split(pds.incremented_white_defender_defeats(p, g)),
-        // TODO: camera target x < 29.5
         Split::WhiteDefenderStatueUnlocked => should_split(pds.dung_defender_awake_convo_on_entry(p, g)
-                                                           && g.get_scene_name(p).is_some_and(|s| s.starts_with("Waterways_15"))),
+                                                           && g.get_scene_name(p).is_some_and(|s| s.starts_with("Waterways_15"))
+                                                           && g.camera_target_destination(p).is_some_and(|v| v.x < 29.5)),
         Split::MetEmilitia => should_split(g.met_emilitia(p).is_some_and(|m| m)),
         Split::GivenEmilitiaFlower => should_split(g.given_emilitia_flower(p).is_some_and(|g| g)),
         Split::Flukemarm => should_split(g.killed_fluke_mother(p).is_some_and(|k| k)),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -4069,7 +4069,9 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::WhiteDefender => should_split(g.killed_white_defender(p).is_some_and(|k| k)),
         Split::WhiteDefenderEssence => should_split(g.white_defender_orbs_collected(p).is_some_and(|o| o)),
         Split::OnDefeatWhiteDefender => should_split(pds.incremented_white_defender_defeats(p, g)),
-        Split::WhiteDefenderStatueUnlocked => todo!("WhiteDefenderStatueUnlocked"),
+        // TODO: camera target x < 29.5
+        Split::WhiteDefenderStatueUnlocked => should_split(pds.dung_defender_awake_convo_on_entry(p, g)
+                                                           && g.get_scene_name(p).is_some_and(|s| s.starts_with("Waterways_15"))),
         Split::MetEmilitia => should_split(g.met_emilitia(p).is_some_and(|m| m)),
         Split::GivenEmilitiaFlower => should_split(g.given_emilitia_flower(p).is_some_and(|g| g)),
         Split::Flukemarm => should_split(g.killed_fluke_mother(p).is_some_and(|k| k)),


### PR DESCRIPTION
Closes #60.

- [x] Figure out what `dungDefenderAwoken` means. Is it really necessary, or is just `dungDefenderAwakeConvo` enough?
  - Turns true on the transition from `Dream_04_White_Defender` to `Waterways_15` after `whiteDefenderDefeats: 5`.
- [x] Figure out what `dungDefenderLeft` means. Is it really necessary, or is just `dungDefenderAwakeConvo` enough?
  - Turns true when the knight gets up after that transition from the dream.
- [x] Figure out what `dungDefenderAwakeConvo` means.
  - Turns true when the knight either talks to Dung Defender after that, or leaves the room to skip the conversation.
  - In the current code, this works when the knight leaves the room, but splits too early when the knight talks to Dung Defender.
  - Perhaps "`dungDefenderAwakeConvo` on-entry" would be better.
- [x] What is the `mem.GetCameraTarget().X < 29.5` doing there? Is there a better way?
  - The camera target X jumps suddenly from exactly `38.5` when the statue is *not* visible, to values less than `30.0`, such as `29.937702178955078` when the statue becomes visible. It does not have to be less than `29.5` for it to be visible.
  - On further investigation, it appears that Lantern matters. Without lantern, the statue is only visible with X < `29.5`, but with Lantern, the statue is visible with X < `30.0`.
- [x] Make sure it only splits after leaving and re-entering the room so it's in the stinky-statue state. Don't immediately split on the conversation.