### PR TITLE
TransitionAfterSaveState: no dreamGate

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -190,6 +190,7 @@ struct GameManagerPointers {
     version_number: UnityPointer<4>,
     scene_name: UnityPointer<2>,
     next_scene_name: UnityPointer<2>,
+    entry_gate_name: UnityPointer<2>,
     game_state: UnityPointer<2>,
     ui_state_vanilla: UnityPointer<3>,
     ui_state_modded: UnityPointer<3>,
@@ -211,6 +212,7 @@ impl GameManagerPointers {
             version_number: UnityPointer::new("GameManager", 0, &["_instance", "<inputHandler>k__BackingField", "debugInfo", "versionNumber"]),
             scene_name: UnityPointer::new("GameManager", 0, &["_instance", "sceneName"]),
             next_scene_name: UnityPointer::new("GameManager", 0, &["_instance", "nextSceneName"]),
+            entry_gate_name: UnityPointer::new("GameManager", 0, &["_instance", "entryGateName"]),
             game_state: UnityPointer::new("GameManager", 0, &["_instance", "gameState"]),
             ui_state_vanilla: UnityPointer::new("GameManager", 0, &["_instance", "<ui>k__BackingField", "uiState"]),
             ui_state_modded: UnityPointer::new("GameManager", 0, &["_instance", "_uiInstance", "uiState"]),
@@ -1091,6 +1093,11 @@ impl GameManagerFinder {
 
     pub fn get_next_scene_name(&self, process: &Process) -> Option<String> {
         let s = self.deref_pointer(process, &self.pointers.next_scene_name).ok()?;
+        read_string_object::<SCENE_PATH_SIZE>(process, &self.string_list_offests, s)
+    }
+
+    pub fn get_entry_gate_name(&self, process: &Process) -> Option<String> {
+        let s = self.deref_pointer(process, &self.pointers.entry_gate_name).ok()?;
         read_string_object::<SCENE_PATH_SIZE>(process, &self.string_list_offests, s)
     }
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3251,7 +3251,8 @@ pub fn transition_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &GameManag
                                                             || p.current.is_empty()
                                                             || is_menu(p.old)
                                                             || is_debug_save_state_scene(p.old)
-                                                            || is_debug_save_state_scene(p.current))),
+                                                            || is_debug_save_state_scene(p.current)
+                                                            || g.get_entry_gate_name(prc).is_some_and(|e| e == "dreamGate"))),
         // endregion: Start, End, and Menu
 
         // region: Dreamers


### PR DESCRIPTION
Fixes #65.

- [x] Don't split on DreamGate
- [x] Split on transition after DreamGate, from the DreamGate scene
- [x] Split on normal transition, to the DreamGate scene