### PR TITLE
Print setup logs before game is open

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -5,19 +5,16 @@ use std::cmp::min;
 use std::mem;
 use std::collections::BTreeMap;
 use asr::file_format::{elf, pe};
-use asr::future::{next_tick, retry};
+use asr::future::next_tick;
 use asr::watcher::Pair;
 use asr::{Address, PointerSize, Process};
 use asr::game_engine::unity::mono::{self, Image, Module, UnityPointer};
 use asr::string::ArrayWString;
-use ugly_widget::store::StoreGui;
 
 #[cfg(debug_assertions)]
 use std::string::String;
 
 use crate::file;
-use crate::settings_gui::{SettingsGui, TimingMethod};
-use crate::splits::Split;
 
 // --------------------------------------------------------
 
@@ -3460,13 +3457,8 @@ impl SceneDataStore {
 
 // --------------------------------------------------------
 
-pub async fn wait_attach_hollow_knight(gui: &mut SettingsGui, timing_method: &mut TimingMethod, splits: &mut Vec<Split>) -> Process {
-    retry(|| {
-        gui.loop_load_update_store();
-        gui.check_timing_method(timing_method);
-        gui.check_splits(splits);
-        HOLLOW_KNIGHT_NAMES.into_iter().find_map(Process::attach)
-    }).await
+pub fn attach_hollow_knight() -> Option<Process> {
+    HOLLOW_KNIGHT_NAMES.into_iter().find_map(Process::attach)
 }
 
 fn process_pointer_size(process: &Process) -> Option<PointerSize> {

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3460,20 +3460,12 @@ impl SceneDataStore {
 // --------------------------------------------------------
 
 pub async fn wait_attach_hollow_knight(gui: &mut SettingsGui) -> Process {
-    let mut splits = gui.get_splits();
     let mut timing_method = gui.get_timing_method();
+    let mut splits = gui.get_splits();
     retry(|| {
         gui.loop_load_update_store();
-        let new_timing_method = gui.get_timing_method();
-        if new_timing_method != timing_method {
-            timing_method = new_timing_method;
-            asr::print_message(&format!("timing_method: {:?}", timing_method));
-        }
-        let new_splits = gui.get_splits();
-        if new_splits != splits {
-            splits = new_splits;
-            asr::print_message(&format!("splits: {:?}", splits));
-        }
+        gui.check_timing_method(&mut timing_method);
+        gui.check_splits(&mut splits);
         HOLLOW_KNIGHT_NAMES.into_iter().find_map(Process::attach)
     }).await
 }

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -16,7 +16,8 @@ use ugly_widget::store::StoreGui;
 use std::string::String;
 
 use crate::file;
-use crate::settings_gui::SettingsGui;
+use crate::settings_gui::{SettingsGui, TimingMethod};
+use crate::splits::Split;
 
 // --------------------------------------------------------
 
@@ -3459,13 +3460,11 @@ impl SceneDataStore {
 
 // --------------------------------------------------------
 
-pub async fn wait_attach_hollow_knight(gui: &mut SettingsGui) -> Process {
-    let mut timing_method = gui.get_timing_method();
-    let mut splits = gui.get_splits();
+pub async fn wait_attach_hollow_knight(gui: &mut SettingsGui, timing_method: &mut TimingMethod, splits: &mut Vec<Split>) -> Process {
     retry(|| {
         gui.loop_load_update_store();
-        gui.check_timing_method(&mut timing_method);
-        gui.check_splits(&mut splits);
+        gui.check_timing_method(timing_method);
+        gui.check_splits(splits);
         HOLLOW_KNIGHT_NAMES.into_iter().find_map(Process::attach)
     }).await
 }

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -16,6 +16,7 @@ use ugly_widget::store::StoreGui;
 use std::string::String;
 
 use crate::file;
+use crate::settings_gui::SettingsGui;
 
 // --------------------------------------------------------
 
@@ -3458,9 +3459,21 @@ impl SceneDataStore {
 
 // --------------------------------------------------------
 
-pub async fn wait_attach_hollow_knight<G: StoreGui>(gui: &mut G) -> Process {
+pub async fn wait_attach_hollow_knight(gui: &mut SettingsGui) -> Process {
+    let mut splits = gui.get_splits();
+    let mut timing_method = gui.get_timing_method();
     retry(|| {
         gui.loop_load_update_store();
+        let new_timing_method = gui.get_timing_method();
+        if new_timing_method != timing_method {
+            timing_method = new_timing_method;
+            asr::print_message(&format!("timing_method: {:?}", timing_method));
+        }
+        let new_splits = gui.get_splits();
+        if new_splits != splits {
+            splits = new_splits;
+            asr::print_message(&format!("splits: {:?}", splits));
+        }
         HOLLOW_KNIGHT_NAMES.into_iter().find_map(Process::attach)
     }).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,18 +34,19 @@ async fn main() {
     let mut gui = Box::new(SettingsGui::wait_load_merge_register().await);
 
     let mut ticks_since_gui = 0;
+    let mut timing_method = gui.get_timing_method();
     let mut splits = gui.get_splits();
+    asr::print_message(&format!("timing_method: {:?}", timing_method));
     asr::print_message(&format!("splits: {:?}", splits));
 
     let mut auto_reset: &'static [TimerState] = splits::auto_reset_safe(&splits);
 
     loop {
-        let process = wait_attach_hollow_knight(&mut *gui).await;
+        let process = wait_attach_hollow_knight(&mut *gui, &mut timing_method, &mut splits).await;
         process
             .until_closes(async {
                 // TODO: Load some initial information from the process.
                 let mut scene_store = Box::new(SceneStore::new());
-                let mut timing_method = gui.get_timing_method();
                 let mut load_remover = Box::new(TimingMethodLoadRemover::new(timing_method));
 
                 next_tick().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,8 @@ async fn main() {
                 #[cfg(debug_assertions)]
                 asr::print_message(&format!("geo: {:?}", game_manager_finder.get_geo(&process)));
 
-                let gui_splits = gui.get_splits();
-                if gui_splits != splits {
-                    splits = gui_splits;
-                    asr::print_message(&format!("splits: {:?}", splits));
-                    auto_reset = splits::auto_reset_safe(&splits);
+                if let Some(new_splits) = gui.check_splits(&mut splits) {
+                    auto_reset = splits::auto_reset_safe(new_splits);
                 }
 
                 #[cfg(debug_assertions)]
@@ -86,18 +83,12 @@ async fn main() {
                     ticks_since_gui += 1;
                     if TICKS_PER_GUI <= ticks_since_gui && gui.load_update_store_if_unchanged() {
                         if i == 0 && [TimerState::NotRunning, TimerState::Ended].contains(&asr::timer::state()) {
-                            let new_timing_method = gui.get_timing_method();
-                            if new_timing_method != timing_method {
-                                timing_method = new_timing_method;
-                                *load_remover = TimingMethodLoadRemover::new(timing_method);
-                                asr::print_message(&format!("timing_method: {:?}", timing_method));
+                            if let Some(new_timing_method) = gui.check_timing_method(&mut timing_method) {
+                                *load_remover = TimingMethodLoadRemover::new(new_timing_method);
                             }
                         }
-                        let gui_splits = gui.get_splits();
-                        if gui_splits != splits {
-                            splits = gui_splits;
-                            asr::print_message(&format!("splits: {:?}", splits));
-                            auto_reset = splits::auto_reset_safe(&splits);
+                        if let Some(new_splits) = gui.check_splits(&mut splits) {
+                            auto_reset = splits::auto_reset_safe(new_splits);
                         }
                         ticks_since_gui = 0;
                     }

--- a/src/settings_gui.rs
+++ b/src/settings_gui.rs
@@ -65,6 +65,28 @@ impl SettingsGui {
         gui.loop_load_update_store();
         gui
     }
+
+    pub fn check_timing_method(&self, timing_method: &mut TimingMethod) -> Option<TimingMethod> {
+        let new_timing_method = self.get_timing_method();
+        if new_timing_method != *timing_method {
+            *timing_method = new_timing_method;
+            asr::print_message(&format!("timing_method: {:?}", timing_method));
+            Some(new_timing_method)
+        } else {
+            None
+        }
+    }
+
+    pub fn check_splits<'a>(&self, splits: &'a mut Vec<Split>) -> Option<&'a [Split]> {
+        let new_splits = self.get_splits();
+        if new_splits != *splits {
+            *splits = new_splits;
+            asr::print_message(&format!("splits: {:?}", splits));
+            Some(splits)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Gui, Ord, PartialEq, PartialOrd, RadioButtonOptions, Serialize)]


### PR DESCRIPTION
- [x] Test without game open
- [x] Test with game open, NotRunning
- [x] Test with game open, Running
- [ ] Test with game open, Ended (ASR Debugger doesn't allow testing this)
- [x] Print starting state once and only once: timing method and splits
- [x] Print each change once and only once: no need to print the one that didn't change