### PR TITLE
unstable: timer_current_split_index

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,19 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - Stable
+          - Unstable
+        include:
+          - label: Stable
+            postfix: _stable
+            features: ""
+          - label: Unstable
+            postfix: _unstable
+            features: "unstable"
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v3
@@ -27,14 +40,18 @@ jobs:
 
       - name: Build
         run: |
-          cargo release --locked
+          cargo release --locked --features ${{ matrix.features }}
+
+      - name: Prepare Release
+        run: |
+          cp target/wasm32-wasi/release/hollowknight_autosplit_wasm.wasm hollowknight_autosplit_wasm${{ matrix.postfix }}.wasm
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
-          files: target/wasm32-wasi/release/hollowknight_autosplit_wasm.wasm
+          files: hollowknight_autosplit_wasm*.wasm
 
   clippy:
     name: Check clippy lints

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
         include:
           - label: Stable
             postfix: _stable
-            features: ""
+            features: '""'
           - label: Unstable
             postfix: _unstable
-            features: "unstable"
+            features: '"unstable"'
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "asr"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/asr?branch=mono-4#39434211fc1fff8245aae13947e94a61c29e9063"
+source = "git+https://github.com/AlexKnauth/asr?branch=mono-5-split-index#da371f848e31fdf308f8ecc2d4f33e7bf757cbd7"
 dependencies = [
  "arrayvec",
  "asr-derive",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "asr-derive"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/asr?branch=mono-4#39434211fc1fff8245aae13947e94a61c29e9063"
+source = "git+https://github.com/AlexKnauth/asr?branch=mono-5-split-index#da371f848e31fdf308f8ecc2d4f33e7bf757cbd7"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ serde_json = { version = "1" }
 
 xmltree = { version = "0.10.3" }
 
+[features]
+unstable = []
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-asr = { git = "https://github.com/AlexKnauth/asr", branch = "mono-4", features = [
+asr = { git = "https://github.com/AlexKnauth/asr", branch = "mono-5-split-index", features = [
     "alloc", # Working with allocations.
     "derive", # Defining your own settings structs, converting endianness, and binding to .NET classes.
     # "flags", # Working with bit flags.
@@ -33,7 +33,7 @@ serde_json = { version = "1" }
 xmltree = { version = "0.10.3" }
 
 [features]
-unstable = []
+unstable = ["asr/split-index"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An auto splitter for Hollow Knight that supports Windows, Mac, and Linux.
 
 ## Installation
 
-Download the `hollowknight_autosplit_wasm.wasm` file from the [Latest Release](https://github.com/AlexKnauth/hollowknight-autosplit-wasm/releases/latest).
+Download the `hollowknight_autosplit_wasm_stable.wasm` file from the [Latest Release](https://github.com/AlexKnauth/hollowknight-autosplit-wasm/releases/latest).
 
 Or follow the steps in [Compilation](#compilation) and use `target/wasm32-wasi/release/hollowknight_autosplit_wasm.wasm`.
 
@@ -75,7 +75,7 @@ If it does not have a component named `Auto Splitting Runtime`,
 add one using the `+` Plus button -> `Control` -> `Auto Splitting Runtime`.
 Once that's there, click `Layout Settings` -> `Auto Splitting Runtime`,
 and next to `Script Path`, click `Browse...`,
-then navigate to the `hollowknight_autosplit_wasm.wasm` file.
+then navigate to the `hollowknight_autosplit_wasm_stable.wasm` file.
 Then click `Import Splits` and select your splits file.
 
 For hit-counter mode, change the `Timing Method` setting to
@@ -123,7 +123,7 @@ Add OBS Source Livesplit One.
 Properties:
 - Splits: Select your splits file
 - Use local autosplitter: Check
-- Local Auto Splitter file: Select the `hollowknight_autosplit_wasm.wasm` file
+- Local Auto Splitter file: Select the `hollowknight_autosplit_wasm_stable.wasm` file
 - Custom auto splitter settings: Select `Import Splits`
 - Select a file: Select your splits file
 
@@ -158,7 +158,7 @@ Right-click or Control-click for the context menu:
 - Layout, Open... : For the Layout, I recommend you use `.ls1l` layout file for LiveSplit One Druid, not a `.lsl` layout file.
   You can make a `.ls1l` file in the LiveSplit One Web version at https://one.livesplit.org/,
   or you can use the `layout-web.ls1l` file included in this repository as a starting point.
-- Open Auto-splitter... : Select the `hollowknight_autosplit_wasm.wasm` file.
+- Open Auto-splitter... : Select the `hollowknight_autosplit_wasm_stable.wasm` file.
 - Compare Against: Game Time.
 - Settings: Configure the hotkeys you want.
 
@@ -167,6 +167,15 @@ unless either it's explicitly marked as `ManualSplit` or it's the end-split.
 Don't manually split, skip, or undo splits in any other situation.
 The autosplitter will not know that you did that,
 and the autosplitter's state will be out of sync with LiveSplit One Druid's state.
+
+### Unstable version for LiveSplit One Druid only
+
+If you're only going to use this auto-splitter with LiveSplit One Druid 0.4.0 or later,
+you can download the `hollowknight_autosplit_wasm_unstable.wasm` file from the
+[Latest Release](https://github.com/AlexKnauth/hollowknight-autosplit-wasm/releases/latest),
+instead of the stable version.
+
+The unstable version works with manual split/skip/undo when used with LiveSplit One Druid, but it will crash if you try to use it with any other timer.
 
 ## Instructions for livesplit-one-desktop
 
@@ -194,11 +203,11 @@ In the `livesplit-one-desktop` repository, modify the `config.yaml` file so that
 general:
   splits: <path-to-splits.lss>
   timing-method: GameTime
-  auto-splitter: <path-to-hollowknight_autosplit_wasm.wasm>
+  auto-splitter: <path-to-hollowknight_autosplit_wasm_stable.wasm>
 ```
 where you replace `<path-to-splits.lss>` with the path to your splits file,
-and you replace `<path-to-hollowknight_autosplit_wasm.wasm>`
-with a path to the `hollowknight_autosplit_wasm.wasm` file.
+and you replace `<path-to-hollowknight_autosplit_wasm_stable.wasm>`
+with a path to the `hollowknight_autosplit_wasm_stable.wasm` file.
 
 To configure it with a layout file, modify the `config.yaml` file so that it contains
 ```yaml

--- a/crates/ugly_widget/Cargo.toml
+++ b/crates/ugly_widget/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-asr = { git = "https://github.com/AlexKnauth/asr", branch = "mono-4", features = [
+asr = { git = "https://github.com/AlexKnauth/asr", branch = "mono-5-split-index", features = [
     "alloc", # Working with allocations.
     "derive", # Defining your own settings structs, converting endianness, and binding to .NET classes.
     # "flags", # Working with bit flags.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod legacy_xml;
 mod settings_gui;
 mod splits;
 mod timer;
+mod unstable;
 
 use asr::future::{next_tick, retry};
 use asr::Process;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,6 +2,8 @@
 use asr::timer::TimerState;
 use serde::{Deserialize, Serialize};
 
+use crate::unstable::maybe_timer_current_split_index;
+
 pub fn is_timer_state_between_runs(s: TimerState) -> bool {
     s == TimerState::NotRunning || s == TimerState::Ended
 }
@@ -66,6 +68,13 @@ pub struct Timer {
     /// [1,n): Running
     /// n: Ended without knowing auto-reset safe
     i: usize,
+    /// The last observed timer_current_split_index.
+    /// Just in case timer_current_split_index is a tad out-of-date.
+    /// -2: Unknown
+    /// -1: NotRunning
+    /// [0,n-1): Running
+    /// n-1: Ended
+    last_split_index: i32,
     /// Number of autosplits including both start and end.
     /// One more than the number of segments.
     n: usize,
@@ -84,10 +93,12 @@ impl Resettable for Timer {
 impl Timer {
     pub fn new(n: usize, auto_reset: &'static [TimerState]) -> Timer {
         let asr_state = asr::timer::state();
+        let asr_index = maybe_timer_current_split_index();
         Timer {
             state: asr_state,
             last_state: asr_state,
             i: 0,
+            last_split_index: asr_index.unwrap_or(-2),
             n,
             auto_reset,
         }
@@ -111,6 +122,12 @@ impl Timer {
     }
 
     pub fn update<R: Resettable>(&mut self, r: &mut R) {
+        self.update_state(r);
+        #[cfg(feature = "unstable")]
+        self.update_index();
+    }
+
+    fn update_state<R: Resettable>(&mut self, r: &mut R) {
         let asr_state = asr::timer::state();
         if asr_state == self.state || asr_state == self.last_state {
             self.last_state = asr_state;
@@ -146,6 +163,33 @@ impl Timer {
         self.last_state = asr_state;
     }
 
+    #[cfg(feature = "unstable")]
+    fn update_index(&mut self) -> Option<()>  {
+        let asr_index = maybe_timer_current_split_index()?;
+        if asr_index == self.last_split_index
+        {
+            return Some(());
+        }
+        let delta = asr_index + 1 - self.i as i32;
+        if delta == 0 || delta >= self.n as i32 {
+            return Some(());
+        }
+        match delta {
+            -1 => asr::print_message("Detected a manual undo."),
+            1 => asr::print_message("Detected a manual split or skip."),
+            d if d.is_negative() => asr::print_message(&format!("Detected a {} manual undos.", -d)),
+            d if d.is_positive() => asr::print_message(&format!("Detected a {} manual splits or skips.", d)),
+            _ => (),
+        }
+        let new_i = (self.i as i32 + delta) as usize;
+        if new_i >= self.n && self.is_auto_reset_safe() {
+            self.i = 0;
+        } else {
+            self.i = new_i;
+        }
+        Some(())
+    }
+
     pub fn action<R: Resettable>(&mut self, a: SplitterAction, r: &mut R) {
         match a {
             SplitterAction::Pass => (),
@@ -169,7 +213,7 @@ impl Timer {
                 self.i += 1;
             }
             SplitterAction::ManualSplit => {
-                if 0 < self.i && self.i + 1 < self.n {
+                if self.last_split_index == -2 && 0 < self.i && self.i + 1 < self.n {
                     self.i += 1;
                 }
             }

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -1,0 +1,22 @@
+
+#[cfg(feature = "unstable")]
+extern "C" {
+    /// Accesses the index of the split the attempt is currently on. If there's
+    /// no attempt in progress, `-1` is returned instead. This returns an
+    /// index that is equal to the amount of segments when the attempt is
+    /// finished, but has not been reset. So you need to be careful when using
+    /// this value for indexing.
+    fn timer_current_split_index() -> i32;
+}
+
+/// Accesses the index of the split the attempt is currently on. If there's
+/// no attempt in progress, `-1` is returned instead. This returns an
+/// index that is equal to the amount of segments when the attempt is
+/// finished, but has not been reset. So you need to be careful when using
+/// this value for indexing.
+pub fn maybe_timer_current_split_index() -> Option<i32> {
+    #[cfg(feature = "unstable")]
+    return Some(unsafe { timer_current_split_index() });
+    #[allow(unreachable_code)]
+    None
+}

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -1,14 +1,4 @@
 
-#[cfg(feature = "unstable")]
-extern "C" {
-    /// Accesses the index of the split the attempt is currently on. If there's
-    /// no attempt in progress, `-1` is returned instead. This returns an
-    /// index that is equal to the amount of segments when the attempt is
-    /// finished, but has not been reset. So you need to be careful when using
-    /// this value for indexing.
-    fn timer_current_split_index() -> i32;
-}
-
 /// Accesses the index of the split the attempt is currently on. If there's
 /// no attempt in progress, `-1` is returned instead. This returns an
 /// index that is equal to the amount of segments when the attempt is
@@ -16,7 +6,7 @@ extern "C" {
 /// this value for indexing.
 pub fn maybe_timer_current_split_index() -> Option<i32> {
     #[cfg(feature = "unstable")]
-    return Some(unsafe { timer_current_split_index() });
+    return Some(asr::timer::current_split_index());
     #[allow(unreachable_code)]
     None
 }


### PR DESCRIPTION
Only merge after https://github.com/AlexKnauth/livesplit-one-druid/pull/19 is merged.

- [x] Prepare release: stable and unstable variants
- [x] Test stable with both the old LiveSplit One Druid and existing LiveSplit
- [x] Test unstable with https://github.com/AlexKnauth/livesplit-one-druid/pull/19 and my fork of LiveSplit
- [x] Document stable vs unstable
