### PR TITLE
Even set hits when it hasn't incremented

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,11 @@ impl HitCounter {
             }
         }
 
+        // Even set hits when it hasn't incremented,
+        // in case this auto-splitter is fighting with something else trying to advance the timer.
+        // https://github.com/AlexKnauth/hollowknight-autosplit-wasm/issues/83
+        asr::timer::set_variable_int("hits", self.hits);
+
         Some(())
     }
 }


### PR DESCRIPTION
In case this auto-splitter is fighting with something else trying to advance the timer.

Fixes #83.