### PR TITLE
Fix arena splits kills_decreased_by: is_game_state_non_menu

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3026,10 +3026,11 @@ impl PlayerDataStore {
         match self.kills_on_entry(prc, gmf, key, pointer) {
             None => None,
             Some(kills_on_entry) => {
+                if !gmf.is_game_state_non_menu(prc) {
+                    return None;
+                }
                 let kills_now: i32 = pointer.deref(prc, &gmf.module, &gmf.image).ok()?;
-                if kills_now == 0 && !gmf.is_game_state_non_menu(prc) {
-                    None
-                } else if kills_now + d <= kills_on_entry {
+                if kills_now + d <= kills_on_entry {
                     Some(true)
                 } else if kills_now == 0 {
                     Some(false)

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -3027,7 +3027,9 @@ impl PlayerDataStore {
             None => None,
             Some(kills_on_entry) => {
                 let kills_now: i32 = pointer.deref(prc, &gmf.module, &gmf.image).ok()?;
-                if kills_now + d <= kills_on_entry {
+                if kills_now == 0 && !gmf.is_game_state_non_menu(prc) {
+                    None
+                } else if kills_now + d <= kills_on_entry {
                     Some(true)
                 } else if kills_now == 0 {
                     Some(false)


### PR DESCRIPTION
Fixes #89 and other similar arena splits by fixing `kills_decreased_by` to check `is_game_state_non_menu`.