### PR TITLE
register the variables on start

### DIFF
--- a/src/hit_counter.rs
+++ b/src/hit_counter.rs
@@ -10,7 +10,7 @@ use crate::hollow_knight_memory::*;
 use crate::timer::{Resettable, Timer};
 
 /// The dash symbol to use for generic dashes in text.
-const DASH: &str = "—";
+pub const DASH: &str = "—";
 /// The minus symbol to use for negative numbers.
 const MINUS: &str = "−";
 /// The plus symbol to use for positive numbers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use hollow_knight_memory::*;
 use splits::Split;
 use timer::{Resettable, SplitterAction, Timer};
 use load_remover::LoadRemover;
-use hit_counter::HitCounter;
+use hit_counter::{HitCounter, DASH};
 use ugly_widget::store::StoreGui;
 
 asr::async_main!(stable);
@@ -55,6 +55,14 @@ async fn main() {
     // TODO: Set up some general state and settings.
 
     asr::print_message("Hello, World!");
+
+    // register the variables on start
+    asr::timer::set_variable_int("hits", 0);
+    asr::timer::set_variable_int("segment hits", 0);
+    asr::timer::set_variable("pb hits", DASH);
+    asr::timer::set_variable("comparison hits", DASH);
+    asr::timer::set_variable("delta hits", DASH);
+    asr::timer::set_variable("item", "");
 
     let mut gui = Box::new(SettingsGui::wait_load_merge_register().await);
 


### PR DESCRIPTION
Some variables are initialized with dashes at first. This should put them in the combo-boxes and stuff for layout editing.