### PR TITLE
WaterwaysEntry: include Spike-tunnel left

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -120,8 +120,8 @@ pub static CRYSTAL_PEAK_ENTRY_SCENES: &[&str] = &[
 
 pub static WATERWAYS_ENTRY_SCENES: &[&str] = &[
     "Waterways_01", // Simple Key manhole entrance
-    // Note: Waterways_06 does not show the Area Text
-    "Waterways_07", // Where the Spike-tunnel and KE-Tram-CDash entrances meet
+    "Waterways_06", // Left of Spike-tunnel, Note: Waterways_06 does not show the Area Text
+    "Waterways_07", // Right of Spike-tunnel, Where the Spike-tunnel and KE-Tram-CDash entrances meet
 ];
 
 pub static FOG_CANYON_ENTRY_SCENES: &[&str] = &[

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2204,6 +2204,7 @@ pub enum Split {
     /// Waterways (Transition)
     /// 
     /// Splits on transition to Waterways
+    /// (Simple Key manhole or Spike-tunnel)
     WaterwaysEntry,
     /// Royal Waterways (Area)
     /// 


### PR DESCRIPTION
Currently the Enter Waterways autosplit recognizes Spike-tunnel going right, but not going left... this PR makes it recognize both left and right. This would be used for the Duelist / Bosses Only No Kill meme category to go towards Dung Defender.