### PR TITLE
Add wasm32-unknown-unknown option

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-target = ["wasm32-wasip1", "wasm32-unknown-unknown"]
+target = "wasm32-wasip1"
 rustflags = [
     # The auto splitting runtime supports all the following WASM features.
     "-C", "target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-target = "wasm32-wasip1"
+target = ["wasm32-wasip1", "wasm32-unknown-unknown"]
 rustflags = [
     # The auto splitting runtime supports all the following WASM features.
     "-C", "target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,20 @@ jobs:
         label:
           - Stable
           - Unstable
+          - Unknown
         include:
           - label: Stable
             postfix: _stable
+            target: wasm32-wasip1
             features: '""'
           - label: Unstable
             postfix: _unstable
+            target: wasm32-wasip1
             features: '"unstable"'
+          - label: Unknown
+            postfix: _unknown
+            target: wasm32-unknown-unknown
+            features: '""'
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
@@ -36,15 +43,15 @@ jobs:
         uses: hecrj/setup-rust-action@v2
         with:
           rust-version: stable
-          targets: wasm32-wasip1
+          targets: ${{matrix.target}}
 
       - name: Build
         run: |
-          cargo release --locked --features ${{ matrix.features }}
+          cargo release --locked --target ${{matrix.target}} --features ${{ matrix.features }}
 
       - name: Prepare Release
         run: |
-          cp target/wasm32-wasip1/release/hollowknight_autosplit_wasm.wasm hollowknight_autosplit_wasm${{ matrix.postfix }}.wasm
+          cp target/${{matrix.target}}/release/hollowknight_autosplit_wasm.wasm hollowknight_autosplit_wasm${{ matrix.postfix }}.wasm
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/src/auto_splitter_settings.rs
+++ b/src/auto_splitter_settings.rs
@@ -5,9 +5,9 @@ use asr::future::retry;
 use std::path::Path;
 use xmltree::{Element, XMLNode};
 
-use crate::{asr_xml, legacy_xml};
 #[cfg(target_os = "wasi")]
 use crate::file;
+use crate::{asr_xml, legacy_xml};
 
 pub async fn wait_asr_settings_init() -> asr::settings::Map {
     let settings1 = asr::settings::Map::load();

--- a/src/auto_splitter_settings.rs
+++ b/src/auto_splitter_settings.rs
@@ -1,10 +1,13 @@
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 use asr::future::retry;
+#[cfg(target_os = "wasi")]
 use std::path::Path;
 use xmltree::{Element, XMLNode};
 
-use crate::{asr_xml, file, legacy_xml};
+use crate::{asr_xml, legacy_xml};
+#[cfg(target_os = "wasi")]
+use crate::file;
 
 pub async fn wait_asr_settings_init() -> asr::settings::Map {
     let settings1 = asr::settings::Map::load();
@@ -32,6 +35,7 @@ pub async fn wait_asr_settings_init() -> asr::settings::Map {
 
 // --------------------------------------------------------
 
+#[cfg(target_os = "wasi")]
 pub fn asr_settings_from_file<P: AsRef<Path>>(path: P) -> Option<asr::settings::Map> {
     let xml_nodes = file_find_auto_splitter_settings(path)?;
     asr_settings_from_xml_nodes(xml_nodes)
@@ -50,6 +54,7 @@ fn asr_settings_from_xml_nodes(xml_nodes: Vec<XMLNode>) -> Option<asr::settings:
     }
 }
 
+#[cfg(target_os = "wasi")]
 fn file_find_auto_splitter_settings<P: AsRef<Path>>(path: P) -> Option<Vec<XMLNode>> {
     let bs = file::file_read_all_bytes(path).ok()?;
     let es = Element::parse_all(bs.as_slice()).ok()?;
@@ -57,6 +62,7 @@ fn file_find_auto_splitter_settings<P: AsRef<Path>>(path: P) -> Option<Vec<XMLNo
     Some(auto_splitter_settings)
 }
 
+#[cfg(target_os = "wasi")]
 fn xml_find_auto_splitter_settings(xml: &XMLNode) -> Option<Vec<XMLNode>> {
     let e = xml.as_element()?;
     match e.name.as_str() {
@@ -72,6 +78,7 @@ fn xml_find_auto_splitter_settings(xml: &XMLNode) -> Option<Vec<XMLNode>> {
     }
 }
 
+#[cfg(target_os = "wasi")]
 fn component_is_asr(e: &Element) -> bool {
     let Some(p) = e.get_child("Path") else {
         return false;

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "wasi")]
 use asr::file_format::{elf, pe};
 use asr::future::{next_tick, retry};
 use asr::game_engine::unity::mono::{self, Image, Module, UnityPointer};
@@ -13,6 +14,7 @@ use std::mem;
 #[cfg(debug_assertions)]
 use std::string::String;
 
+#[cfg(target_os = "wasi")]
 use crate::file;
 
 // --------------------------------------------------------
@@ -2479,11 +2481,15 @@ impl GameManagerFinder {
     }
 
     pub async fn wait_attach(process: &Process) -> GameManagerFinder {
+        #[cfg(target_os = "wasi")]
         let pointer_size = process_pointer_size(process).unwrap_or(PointerSize::Bit64);
+        #[cfg(target_os = "wasi")]
         asr::print_message(&format!(
             "GameManagerFinder wait_attach: pointer_size = {:?}",
             pointer_size
         ));
+        #[cfg(not(target_os = "wasi"))]
+        let pointer_size = PointerSize::Bit64;
         asr::print_message("GameManagerFinder wait_attach: Module wait_attach_auto_detect...");
         next_tick().await;
         let mut found_module = false;
@@ -7356,6 +7362,7 @@ pub fn attach_hollow_knight() -> Option<Process> {
     HOLLOW_KNIGHT_NAMES.into_iter().find_map(Process::attach)
 }
 
+#[cfg(target_os = "wasi")]
 fn process_pointer_size(process: &Process) -> Option<PointerSize> {
     let path = process.get_path().ok()?;
     let bytes = file::file_read_all_bytes(path).ok()?;

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -5005,7 +5005,9 @@ impl SceneStore {
         if let Some(sm) = msm {
             self.new_all_scene_names(
                 sm.scenes(prc)
-                    .filter_map(|s| scene_path_to_name_string(s.path::<SCENE_PATH_SIZE>(prc, sm).ok()?))
+                    .filter_map(|s| {
+                        scene_path_to_name_string(s.path::<SCENE_PATH_SIZE>(prc, sm).ok()?)
+                    })
                     .collect(),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 
 mod asr_xml;
 mod auto_splitter_settings;
+#[cfg(target_os = "wasi")]
 mod file;
 mod game_time;
 mod hit_counter;

--- a/src/settings_gui.rs
+++ b/src/settings_gui.rs
@@ -1,24 +1,33 @@
+use asr::settings::gui::{Gui, Title};
+#[cfg(target_os = "wasi")]
 use asr::{
-    settings::gui::{FileSelect, Gui, Title, Widget},
+    settings::gui::{FileSelect, Widget},
     watcher::Pair,
 };
 
 use serde::{Deserialize, Serialize};
 use ugly_widget::{
-    args::SetHeadingLevel,
     radio_button::{options_str, RadioButtonOptions},
     store::{StoreGui, StoreWidget},
-    ugly_list::{UglyList, UglyListArgs},
+    ugly_list::UglyList,
+};
+#[cfg(target_os = "wasi")]
+use ugly_widget::{
+    args::SetHeadingLevel,
+    ugly_list::UglyListArgs,
 };
 
 use crate::{
-    auto_splitter_settings::{asr_settings_from_file, wait_asr_settings_init},
+    auto_splitter_settings::wait_asr_settings_init,
     splits::Split,
 };
+#[cfg(target_os = "wasi")]
+use crate::auto_splitter_settings::asr_settings_from_file;
 
 #[derive(Gui)]
 pub struct SettingsGui {
     /// Import Splits
+    #[cfg(target_os = "wasi")]
     #[filter((_, "*.lss *.lsl"))]
     import: Pair<FileSelect>,
     /// General Settings
@@ -34,6 +43,7 @@ pub struct SettingsGui {
 
 impl StoreGui for SettingsGui {
     fn post_update(&mut self) {
+        #[cfg(target_os = "wasi")]
         if self.import.changed() {
             asr::print_message(&format!("import {}", self.import.current.path));
             if let Some(settings_map) = asr_settings_from_file(&self.import.current.path) {

--- a/src/settings_gui.rs
+++ b/src/settings_gui.rs
@@ -6,23 +6,17 @@ use asr::{
 };
 
 use serde::{Deserialize, Serialize};
+#[cfg(target_os = "wasi")]
+use ugly_widget::{args::SetHeadingLevel, ugly_list::UglyListArgs};
 use ugly_widget::{
     radio_button::{options_str, RadioButtonOptions},
     store::{StoreGui, StoreWidget},
     ugly_list::UglyList,
 };
-#[cfg(target_os = "wasi")]
-use ugly_widget::{
-    args::SetHeadingLevel,
-    ugly_list::UglyListArgs,
-};
 
-use crate::{
-    auto_splitter_settings::wait_asr_settings_init,
-    splits::Split,
-};
 #[cfg(target_os = "wasi")]
 use crate::auto_splitter_settings::asr_settings_from_file;
+use crate::{auto_splitter_settings::wait_asr_settings_init, splits::Split};
 
 #[derive(Gui)]
 pub struct SettingsGui {


### PR DESCRIPTION
Add wasm32-unknown-unknown option, just in case going without WASI might help get around a failure to load the autosplitter on some systems.