### PR TITLE
Add PetraArena mini boss split

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -6025,6 +6025,17 @@ impl PlayerDataStore {
         )
     }
 
+    pub fn petra_arena(&mut self, prc: &Process, gmf: &GameManagerFinder) -> Option<bool> {
+        // Mantis Petra: {0} +3 {3}
+        self.kills_decreased_by(
+            prc,
+            gmf,
+            "kills_mantis_heavy_flyer_on_entry",
+            &gmf.player_data_pointers.kills_mantis_heavy_flyer,
+            3,
+        )
+    }
+
     pub fn bronze1a(&mut self, prc: &Process, gmf: &GameManagerFinder) -> Option<bool> {
         // Shielded Fool: {0} +1 {1}
         self.kills_decreased_by(

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2947,6 +2947,10 @@ pub enum Split {
     ///
     /// Splits when entering Queen's Gardens text first appears
     QueensGardens,
+    /// Petra Arena (Mini Boss)
+    ///
+    /// Splits when killing 3 Mantis Petras in a row (ideally Petra Arena)
+    PetraArena,
     /// Queen's Garden Bench (Toll)
     ///
     /// Splits when buying Queen's Garden toll bench
@@ -5162,6 +5166,7 @@ pub fn continuous_splits(
         // endregion: Fog Canyon
         // region: Queen's Gardens
         Split::QueensGardens => should_split(g.visited_royal_gardens(p).is_some_and(|v| v)),
+        Split::PetraArena => should_split_skip(pds.petra_arena(p, g)),
         Split::TollBenchQG => should_split(g.toll_bench_queens_gardens(p).is_some_and(|b| b)),
         Split::FlowerQuest => should_split(g.xun_flower_given(p).is_some_and(|g| g)),
         Split::Marmu => should_split(g.killed_ghost_marmu(p).is_some_and(|k| k)),


### PR DESCRIPTION
Splits when killing 3 Mantis Petras in a row (ideally Petra Arena)

Tasks:
- [ ] Test with various numbers of Petras killed before entering the arena
- [ ] Look into whether it should need to check the current scene name (`Fungus3_05`)