### PR TITLE
Fix Hornet1 to not split on Hornet2

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -558,7 +558,7 @@ struct PlayerDataPointers {
     visited_greenpath: UnityPointer<3>,
     killed_moss_knight: UnityPointer<3>,
     zote_rescued_buzzer: UnityPointer<3>,
-    killed_hornet: UnityPointer<3>,
+    hornet1_defeated: UnityPointer<3>,
     /// killedLazyFlyer: Aluba
     killed_lazy_flyer: UnityPointer<3>,
     killed_hunter_mark: UnityPointer<3>,
@@ -1632,10 +1632,10 @@ impl PlayerDataPointers {
                 0,
                 &["_instance", "playerData", "zoteRescuedBuzzer"],
             ),
-            killed_hornet: UnityPointer::new(
+            hornet1_defeated: UnityPointer::new(
                 "GameManager",
                 0,
-                &["_instance", "playerData", "killedHornet"],
+                &["_instance", "playerData", "hornet1Defeated"],
             ),
             killed_lazy_flyer: UnityPointer::new(
                 "GameManager",
@@ -4069,9 +4069,9 @@ impl GameManagerFinder {
             .ok()
     }
 
-    pub fn killed_hornet(&self, process: &Process) -> Option<bool> {
+    pub fn hornet1_defeated(&self, process: &Process) -> Option<bool> {
         self.player_data_pointers
-            .killed_hornet
+            .hornet1_defeated
             .deref(process, &self.module, &self.image)
             .ok()
     }

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -4858,7 +4858,7 @@ pub fn continuous_splits(
             g.at_bench(p).is_some_and(|b| b)
                 && g.get_scene_name(p).is_some_and(|s| s == "Fungus1_16_alt"),
         ),
-        Split::Hornet1 => should_split(g.killed_hornet(p).is_some_and(|k| k)),
+        Split::Hornet1 => should_split(g.hornet1_defeated(p).is_some_and(|k| k)),
         Split::Aluba => should_split(g.killed_lazy_flyer(p).is_some_and(|k| k)),
         Split::HuntersMark => should_split(g.killed_hunter_mark(p).is_some_and(|k| k)),
         Split::NoEyes => should_split(g.killed_ghost_no_eyes(p).is_some_and(|k| k)),


### PR DESCRIPTION
Testing:
- [x] Test Reverse Hornet Order splits: `Hornet2`, `Hornet1`
