### PR TITLE
Add EnterQueensGardensOrDeepnest transition split

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -136,8 +136,15 @@ pub static QUEENS_GARDENS_ENTRY_SCENES: &[&str] = &["Fungus3_34", "Deepnest_43"]
 pub static DEEPNEST_ENTRY_SCENES: &[&str] = &[
     "Fungus2_25",   // Room after Mantis Lords
     "Deepnest_42",  // Room outside Mask Maker
-    "Abyss_03b",    // Deepnest Tram
+    "Abyss_03_b",   // Deepnest Tram
     "Deepnest_01b", // Near Spore Shroom
+];
+
+pub static QUEENS_GARDENS_OR_DEEPNEST_ENTRY_SCENES: &[&str] = &[
+    "Fungus3_34",   // Queen's Gardens entrance from QGA or Overgrown Mound
+    "Fungus2_25",   // Deepnest entrance from Mantis Lords or Fungal Core
+    "Abyss_03_b",   // Deepnest entrance from Tram
+    "Deepnest_01b", // Deepnest entrance from Fungal near Spore Shroom
 ];
 
 pub static GODHOME_LORE_SCENES: &[&str] = &[

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2939,6 +2939,10 @@ pub enum Split {
     Uumuu,
     // endregion: Fog Canyon
     // region: Queen's Gardens
+    /// Queen's Gardens or Deepnest (Transition)
+    ///
+    /// Splits on transition into either Queen's Gardens or Deepnest
+    EnterQueensGardensOrDeepnest,
     /// Queen's Garden Entry (Transition)
     ///
     /// Splits on transition to QG scene following QGA or above Deepnest
@@ -3657,6 +3661,10 @@ pub fn transition_splits(
         ),
         // endregion: Fog Canyon
         // region: Queen's Gardens
+        Split::EnterQueensGardensOrDeepnest => should_split(
+            starts_with_any(p.current, QUEENS_GARDENS_OR_DEEPNEST_ENTRY_SCENES)
+                && p.current != p.old,
+        ),
         Split::QueensGardensEntry => should_split(
             starts_with_any(p.current, QUEENS_GARDENS_ENTRY_SCENES) && p.current != p.old,
         ),


### PR DESCRIPTION
Adds a transition autosplit for entering either Queen's Gardens or Deepnest. Intended to be used in "flexible" Any% splits so that runners can choose to go through either QGA route or Deepnest route.

Resolves #123 