### PR TITLE
Add CrystalPeakHuntersNotes journal split

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -621,6 +621,11 @@ struct PlayerDataPointers {
     // Crystal Guardian
     defeated_mega_beam_miner: UnityPointer<3>,
     kills_mega_beam_miner: UnityPointer<3>,
+    kills_laser_bug: UnityPointer<3>,
+    kills_crystal_flyer: UnityPointer<3>,
+    kills_beam_miner: UnityPointer<3>,
+    kills_crystal_crawler: UnityPointer<3>,
+    kills_mines_crawler: UnityPointer<3>,
     mine_lift_opened: UnityPointer<3>,
     opened_waterways_manhole: UnityPointer<3>,
     visited_waterways: UnityPointer<3>,
@@ -1876,6 +1881,31 @@ impl PlayerDataPointers {
                 "GameManager",
                 0,
                 &["_instance", "playerData", "killsMegaBeamMiner"],
+            ),
+            kills_laser_bug: UnityPointer::new(
+                "GameManager",
+                0,
+                &["_instance", "playerData", "killsLaserBug"],
+            ),
+            kills_crystal_flyer: UnityPointer::new(
+                "GameManager",
+                0,
+                &["_instance", "playerData", "killsCrystalFlyer"],
+            ),
+            kills_beam_miner: UnityPointer::new(
+                "GameManager",
+                0,
+                &["_instance", "playerData", "killsBeamMiner"],
+            ),
+            kills_crystal_crawler: UnityPointer::new(
+                "GameManager",
+                0,
+                &["_instance", "playerData", "killsCrystalCrawler"],
+            ),
+            kills_mines_crawler: UnityPointer::new(
+                "GameManager",
+                0,
+                &["_instance", "playerData", "killsMinesCrawler"],
             ),
             mine_lift_opened: UnityPointer::new(
                 "GameManager",
@@ -4307,6 +4337,54 @@ impl GameManagerFinder {
     pub fn kills_mega_beam_miner(&self, process: &Process) -> Option<i32> {
         self.player_data_pointers
             .kills_mega_beam_miner
+            .deref(process, &self.module, &self.image)
+            .ok()
+    }
+
+    /// Kills left to complete Crystal Crawler journal
+    pub fn kills_laser_bug(&self, process: &Process) -> Option<i32> {
+        self.player_data_pointers
+            .kills_laser_bug
+            .deref(process, &self.module, &self.image)
+            .ok()
+    }
+
+    /// Kills left to complete Crystal Hunter journal
+    pub fn kills_crystal_flyer(&self, process: &Process) -> Option<i32> {
+        self.player_data_pointers
+            .kills_crystal_flyer
+            .deref(process, &self.module, &self.image)
+            .ok()
+    }
+
+    /// Kills left to complete Crystallised Husk journal
+    pub fn kills_beam_miner(&self, process: &Process) -> Option<i32> {
+        self.player_data_pointers
+            .kills_beam_miner
+            .deref(process, &self.module, &self.image)
+            .ok()
+    }
+
+    /// Kills left to complete Glimback journal
+    pub fn kills_crystal_crawler(&self, process: &Process) -> Option<i32> {
+        self.player_data_pointers
+            .kills_crystal_crawler
+            .deref(process, &self.module, &self.image)
+            .ok()
+    }
+
+    /// Kills left to complete Husk Miner journal
+    pub fn kills_zombie_miner(&self, process: &Process) -> Option<i32> {
+        self.player_data_pointers
+            .kills_zombie_miner
+            .deref(process, &self.module, &self.image)
+            .ok()
+    }
+
+    /// Kills left to complete Shardmite journal
+    pub fn kills_mines_crawler(&self, process: &Process) -> Option<i32> {
+        self.player_data_pointers
+            .kills_mines_crawler
             .deref(process, &self.module, &self.image)
             .ok()
     }

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2233,6 +2233,14 @@ pub enum Split {
     ///
     /// Splits on transition from Crystal Mound
     CrystalMoundExit,
+    /// Crystal Peak Hunter's Notes (Killed)
+    ///
+    /// Splits when killing all Crystal Peak enemies needed for Hunter's Notes journal completion
+    ///
+    /// (Includes Crystal Crawler, Crystal Guardian 1&2, Crystal Hunter,
+    /// Crystallised Husk, Glimback, Husk Miner, and Shardmite.
+    /// Excludes Bluggsac, Grimmkin Novice, and Grub Mimic.)
+    CrystalPeakHuntersNotes,
     /// Crystal Peak Lift Opened (Event)
     ///
     /// Splits when opening the lever for the lift between Dirtmouth and Crystal Peak
@@ -4995,6 +5003,15 @@ pub fn continuous_splits(
         Split::HuskMiner => should_split(pds.decremented_kills_zombie_miner(p, g)),
         Split::CrystalGuardian1 => should_split(g.defeated_mega_beam_miner(p).is_some_and(|k| k)),
         Split::CrystalGuardian2 => should_split(g.kills_mega_beam_miner(p).is_some_and(|k| k == 0)),
+        Split::CrystalPeakHuntersNotes => should_split(
+            g.kills_laser_bug(p).is_some_and(|k| k == 0) // Crystal Crawler
+                && g.kills_mega_beam_miner(p).is_some_and(|k| k == 0) // Crystal Guardian 1&2
+                && g.kills_crystal_flyer(p).is_some_and(|k| k == 0) // Crystal Hunter
+                && g.kills_beam_miner(p).is_some_and(|k| k == 0) // Crystallised Husk
+                && g.kills_crystal_crawler(p).is_some_and(|k| k == 0) // Glimback
+                && g.kills_zombie_miner(p).is_some_and(|k| k == 0) // Husk Miner
+                && g.kills_mines_crawler(p).is_some_and(|k| k == 0), // Shardmite
+        ),
         Split::MineLiftOpened => should_split(g.mine_lift_opened(p).is_some_and(|o| o)),
         // endregion: Peak
         // region: Waterways


### PR DESCRIPTION
Adds a journal autosplit for killing all Crystal Peak enemies needed for Hunter's Notes journal completion. Includes Crystal Crawler, Crystal Guardian 1&2, Crystal Hunter, Crystallised Husk, Glimback, Husk Miner, and Shardmite. Excludes Bluggsac, Grimmkin Novice, and Grub Mimic. Intended to be used in All Achievements speedruns.