### PR TITLE
Add script_name

### DIFF
--- a/splits/all_skills_shuffle/all_skills_shuffle-lso.lss
+++ b/splits/all_skills_shuffle/all_skills_shuffle-lso.lss
@@ -240,6 +240,7 @@
     <Version>1.0.0.0</Version>
     <ScriptPath />
     <CustomSettings>
+      <Setting id="script_name" type="string" value="hollowknight_autosplit_wasm" />
       <Setting id="splits" type="list">
         <Setting type="string" value="RandoWake" />
         <Setting type="string" value="OnObtainAllSkillsShuffleItem" />

--- a/splits/current/layout-windows-ls.lsl
+++ b/splits/current/layout-windows-ls.lsl
@@ -216,6 +216,7 @@
         <Version>1.0</Version>
         <ScriptPath>C:\Users\Owner\Documents\git\LiveSplit\hollowknight-autosplit-wasm\target\wasm32-wasip1\release\hollowknight_autosplit_wasm.wasm</ScriptPath>
         <CustomSettings>
+          <Setting id="script_name" type="string" value="hollowknight_autosplit_wasm" />
           <Setting id="splits" type="list">
             <Setting type="string" value="StartNewGame" />
             <Setting type="string" value="KingsPass" />

--- a/splits/current/splits-lso.lss
+++ b/splits/current/splits-lso.lss
@@ -163,6 +163,7 @@
     <Version>1.0.0.0</Version>
     <ScriptPath />
     <CustomSettings>
+      <Setting id="script_name" type="string" value="hollowknight_autosplit_wasm" />
       <Setting id="splits" type="list">
         <Setting type="string" value="StartNewGame" />
         <Setting type="string" value="KingsPass" />

--- a/splits/hits/hits-lrt-lso.lss
+++ b/splits/hits/hits-lrt-lso.lss
@@ -163,6 +163,7 @@
     <Version>1.0.0.0</Version>
     <ScriptPath />
     <CustomSettings>
+      <Setting id="script_name" type="string" value="hollowknight_autosplit_wasm" />
       <Setting id="splits" type="list">
         <Setting type="string" value="StartNewGame" />
         <Setting type="string" value="KingsPass" />

--- a/splits/hits/hits-lso.lss
+++ b/splits/hits/hits-lso.lss
@@ -163,6 +163,7 @@
     <Version>1.0.0.0</Version>
     <ScriptPath />
     <CustomSettings>
+      <Setting id="script_name" type="string" value="hollowknight_autosplit_wasm" />
       <Setting id="splits" type="list">
         <Setting type="string" value="StartNewGame" />
         <Setting type="string" value="KingsPass" />

--- a/splits/hits/hits-windows-ls.lsl
+++ b/splits/hits/hits-windows-ls.lsl
@@ -200,6 +200,7 @@
         <Version>1.0</Version>
         <ScriptPath>C:\Users\Owner\Documents\git\LiveSplit\hollowknight-autosplit-wasm\target\wasm32-wasip1\release\hollowknight_autosplit_wasm.wasm</ScriptPath>
         <CustomSettings>
+          <Setting id="script_name" type="string" value="hollowknight_autosplit_wasm" />
           <Setting id="splits" type="list">
             <Setting type="string" value="StartNewGame" />
             <Setting type="string" value="KingsPass" />

--- a/src/legacy_xml.rs
+++ b/src/legacy_xml.rs
@@ -6,6 +6,7 @@ use asr::settings::AsValue;
 use roxmltree::Node;
 use ugly_widget::radio_button::{options_str, options_value};
 
+use crate::auto_splitter_settings::this_script_name;
 use crate::{
     settings_gui::{HitsMethod, TimingMethod},
     splits::Split,
@@ -19,6 +20,7 @@ pub fn asr_settings_from_xml_nodes(xml_nodes: Vec<Node>) -> Option<asr::settings
     let splits = splits_from_settings(&xml_settings)?;
     // new empty map, which will only include the new splits
     let settings_map = asr::settings::Map::new();
+    settings_map.insert("script_name", this_script_name());
     settings_map.insert("splits", asr_list_from_iter(splits.iter().map(options_str)));
     if let Some(timing_method) = xml_settings.dict_get("TimingMethod") {
         let tm = timing_method_from_settings_str(timing_method).unwrap_or_default();


### PR DESCRIPTION
To avoid overwriting the settings for files which may have been produced for the Silksong autosplitter, and to avoid having settings for this Hollow Knight autosplitter overwritten by the Silksong autosplitter.